### PR TITLE
chore(scripts): improve `publish-package.js`

### DIFF
--- a/move/axelar/Move.toml
+++ b/move/axelar/Move.toml
@@ -1,9 +1,10 @@
 [package]
 name = "Axelar"
 version = "0.0.1"
+published-at = "0x6a1678d3cd93f8b58865a0910f27faf78cbefddc68cd08d5786cb50901f2aa99"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "main" }
 
 [addresses]
 axelar = "0x0"

--- a/move/axelar/Move.toml
+++ b/move/axelar/Move.toml
@@ -1,10 +1,9 @@
 [package]
 name = "Axelar"
 version = "0.0.1"
-published-at = "0x2aaa1a2367e4087a4427593dd311f173d3fd0f632adb494bcd37b2ca969e1eaf"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "main" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
-axelar = "0x2aaa1a2367e4087a4427593dd311f173d3fd0f632adb494bcd37b2ca969e1eaf"
+axelar = "0x0"

--- a/move/axelar/Move.toml
+++ b/move/axelar/Move.toml
@@ -1,10 +1,10 @@
 [package]
 name = "Axelar"
 version = "0.0.1"
-published-at = "0x6a1678d3cd93f8b58865a0910f27faf78cbefddc68cd08d5786cb50901f2aa99"
+published-at = "0x2aaa1a2367e4087a4427593dd311f173d3fd0f632adb494bcd37b2ca969e1eaf"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "main" }
 
 [addresses]
-axelar = "0x0"
+axelar = "0x2aaa1a2367e4087a4427593dd311f173d3fd0f632adb494bcd37b2ca969e1eaf"

--- a/scripts/publish-package.js
+++ b/scripts/publish-package.js
@@ -134,7 +134,6 @@ if (require.main === module) {
         config.packageId = packageId;
         for(const singleton of info.singletons) {
             const object = publishTxn.objectChanges.find(object => (object.objectType === `${packageId}::${singleton}`));
-
             delete object.type;
             delete object.sender;
             delete object.owner;

--- a/scripts/publish-package.js
+++ b/scripts/publish-package.js
@@ -170,6 +170,9 @@ if (require.main === module) {
         
         const allConfigs = fs.existsSync(`../info/${packagePath}.json`) ? require(`../info/${packagePath}.json`) : {};
         allConfigs[env.alias] = config;
+        if (!fs.existsSync('info')){
+            fs.mkdirSync('info');
+        }
         fs.writeFileSync(`info/${packagePath}.json`, JSON.stringify(allConfigs, null, 4));
         updateMoveToml(packagePath, packageId);
     })();

--- a/scripts/publish-package.js
+++ b/scripts/publish-package.js
@@ -100,14 +100,17 @@ function isValidHttpUrl(string) {
 
 if (require.main === module) {
     const packagePath = process.argv[2] || 'axelar';
-    const arg = process.argv[3] ?
-        JSON.parse(process.argv[3]) :
-        {
-            alias: "localnet",
-            url: getFullnodeUrl('localnet')
-        };
-
-    const env = Object.assign(arg, arg.url ? {} : { url: getFullnodeUrl(arg.alias) });
+    const env = ((arg) => {
+        switch (arg?.toLowerCase()) {
+            case 'localnet':
+            case 'devnet':
+            case 'testnet':
+            case 'mainnet':
+                return {alias: arg, url: getFullnodeUrl(arg)};
+            default:
+                return JSON.parse(arg);
+      }
+    })(process.argv[3] || 'localnet');
     const faucet = (process.argv[4]?.toLowerCase?.() === 'true');
     
     (async () => {

--- a/scripts/publish-package.js
+++ b/scripts/publish-package.js
@@ -110,8 +110,6 @@ if (require.main === module) {
     const env = Object.assign(arg, arg.url ? {} : { url: getFullnodeUrl(arg.alias) });
     const faucet = (process.argv[4]?.toLowerCase?.() === 'true');
     
-    console.log(env);
-
     (async () => {
         const privKey = 
         Buffer.from(
@@ -145,7 +143,6 @@ if (require.main === module) {
         config.packageId = packageId;
         for(const singleton of info.singletons) {
             const object = publishTxn.objectChanges.find(object => (object.objectType === `${packageId}::${singleton}`));
-            console.log(object);
 
             delete object.type;
             delete object.sender;

--- a/scripts/publish-package.js
+++ b/scripts/publish-package.js
@@ -86,18 +86,6 @@ function fillAddresses(toml, address) {
     return lines.join('\n');
 }
 
-function isValidHttpUrl(string) {
-    let url;
-    
-    try {
-      url = new URL(string);
-    } catch (_) {
-      return false;  
-    }
-  
-    return url.protocol === "http:" || url.protocol === "https:";
-  }
-
 if (require.main === module) {
     const packagePath = process.argv[2] || 'axelar';
     const env = ((arg) => {


### PR DESCRIPTION
In order to be able to use `scripts/publish-package.js` in devnet orchestration:

* Allowed for passing of entire environment via command argument (i.e., both alias and url instead of only the alias)
* Made usage of faucet optional
* Fixed a few bugs related to importing/saving package info from/to disk