### PR TITLE
[review] 3/X - cleanup, shorter package address, module renames

### DIFF
--- a/move/test/Move.toml
+++ b/move/test/Move.toml
@@ -9,5 +9,5 @@ Axelar = { local = "../axelar" }
 
 [addresses]
 test = "0x996939577aed09e0f9bc6690d85c6bbdb0228353cbe4dbb326b3c2d7f59cbff9"
-interchain_token_service = "0x996939577aed09e0f9bc6690d85c6bbdb0228353cbe4dbb326b3c2d7f59cbff9"
+its = "0x996939577aed09e0f9bc6690d85c6bbdb0228353cbe4dbb326b3c2d7f59cbff9"
 dummy_its = "0x996939577aed09e0f9bc6690d85c6bbdb0228353cbe4dbb326b3c2d7f59cbff9"

--- a/move/test/sources/interchain-token-service/coin_info.move
+++ b/move/test/sources/interchain-token-service/coin_info.move
@@ -1,4 +1,8 @@
-module interchain_token_service::coin_info {
+
+
+/// Defines the `CoinInfo` type which allows to store information about a coin:
+/// either derived from `CoinMetadata` or manually provided.
+module its::coin_info {
     use std::ascii;
     use std::string::String;
     use std::option::{Self, Option};
@@ -20,7 +24,7 @@ module interchain_token_service::coin_info {
             name,
             symbol,
             decimals,
-            metadata: option::none<CoinMetadata<T>>(),
+            metadata: option::none(),
         }
     }
 
@@ -30,7 +34,7 @@ module interchain_token_service::coin_info {
             name: coin::get_name(&metadata),
             symbol: coin::get_symbol(&metadata),
             decimals: coin::get_decimals(&metadata),
-            metadata: option::some<CoinMetadata<T>>(metadata),
+            metadata: option::some(metadata),
         }
     }
 

--- a/move/test/sources/interchain-token-service/coin_management.move
+++ b/move/test/sources/interchain-token-service/coin_management.move
@@ -1,14 +1,13 @@
 
 
-module interchain_token_service::coin_management {
+module its::coin_management {
     use std::option::{Self, Option};
 
     use sui::coin::{Self, TreasuryCap, Coin};
     use sui::balance::{Self, Balance};
-    use sui::transfer;
     use sui::tx_context::TxContext;
 
-    friend interchain_token_service::service;
+    friend its::service;
 
     /// Trying to add a distributor to a `CoinManagement` that does not
     /// have a `TreasuryCap`.
@@ -50,6 +49,7 @@ module interchain_token_service::coin_management {
 
     // === Protected Methods ===
 
+    /// Takes the given amount of Coins from user.
     public(friend) fun take_coin<T>(self: &mut CoinManagement<T>, to_take: Coin<T>) {
         if (has_capability(self)) {
             let cap = option::borrow_mut(&mut self.treasury_cap);
@@ -60,16 +60,10 @@ module interchain_token_service::coin_management {
         }
     }
 
-    /// TODO: consider redundant given the `give_coin` method.
-    public(friend) fun give_coin_to<T>(
-        self: &mut CoinManagement<T>, to: address, amount: u64, ctx: &mut TxContext
-    ) {
-        transfer::public_transfer(give_coin<T>(self, amount, ctx), to);
-    }
-
+    /// Withdraws or mints the given amount of coins.
     public(friend) fun give_coin<T>(
         self: &mut CoinManagement<T>, amount: u64, ctx: &mut TxContext
-    ) : Coin<T> {
+    ): Coin<T> {
         if (has_capability(self)) {
             let cap = option::borrow_mut(&mut self.treasury_cap);
             coin::mint(cap, amount, ctx)

--- a/move/test/sources/interchain-token-service/discovery.move
+++ b/move/test/sources/interchain-token-service/discovery.move
@@ -1,6 +1,6 @@
 
 
-module interchain_token_service::discovery {
+module its::discovery {
     use std::ascii;
     use std::type_name;
     use std::vector;
@@ -13,8 +13,8 @@ module interchain_token_service::discovery {
     use axelar::discovery::{Self, RelayerDiscovery, Transaction};
     use axelar::utils;
 
-    use interchain_token_service::storage::{Self, ITS};
-    use interchain_token_service::token_id;
+    use its::storage::{Self, ITS};
+    use its::token_id;
 
     const EUnsupportedMessageType: u64 = 0;
 
@@ -41,7 +41,7 @@ module interchain_token_service::discovery {
             vector[],
         );
 
-        discovery::register_transaction(discovery, storage::borrow_channel(self), tx);
+        discovery::register_transaction(discovery, storage::channel(self), tx);
     }
 
     public fun get_call_info(self: &ITS, payload: &vector<u8>): Transaction {

--- a/move/test/sources/interchain-token-service/interchain_address_tracker.move
+++ b/move/test/sources/interchain-token-service/interchain_address_tracker.move
@@ -1,24 +1,44 @@
-module interchain_token_service::interchain_address_tracker {
+module its::interchain_address_tracker {
     use std::ascii::String;
 
     use sui::table::{Self, Table};
     use sui::tx_context::{TxContext};
 
-    friend interchain_token_service::storage;
+    friend its::storage;
 
     /// Attempt to borrow a trusted address but it's not registered.
-    const EUntrustedChain: u64 = 0;
+    const ENoAddress: u64 = 0;
 
+    /// The interchain address tracker stores the trusted addresses for each chain.
     struct InterchainAddressTracker has store {
         trusted_addresses: Table<String, String>
     }
 
+    /// Get the trusted address for a chain.
+    public fun get_trusted_address(
+        self: &InterchainAddressTracker, chain_name: String
+    ): &String {
+        assert!(table::contains(&self.trusted_addresses, chain_name), ENoAddress);
+        table::borrow(&self.trusted_addresses, chain_name)
+    }
+
+    /// Check if the given address is trusted for the given chain.
+    public fun is_trusted_address(
+        self: &InterchainAddressTracker, chain_name: String, addr: String
+    ): bool{
+        get_trusted_address(self, chain_name) == &addr
+    }
+
+    // === Protected ===
+
+    /// Create a new interchain address tracker.
     public(friend) fun new(ctx: &mut TxContext): InterchainAddressTracker {
         InterchainAddressTracker {
             trusted_addresses: table::new(ctx),
         }
     }
 
+    /// Set the trusted address for a chain or adds it if it doesn't exist.
     public(friend) fun set_trusted_address(
         self: &mut InterchainAddressTracker,
         chain_name: String,
@@ -29,18 +49,5 @@ module interchain_token_service::interchain_address_tracker {
         } else {
             table::add(&mut self.trusted_addresses, chain_name, trusted_address);
         }
-    }
-
-    public fun borrow_trusted_address(
-        self: &InterchainAddressTracker, chain_name: String
-    ): &String {
-        assert!(table::contains(&self.trusted_addresses, chain_name), EUntrustedChain);
-        table::borrow(&self.trusted_addresses, chain_name)
-    }
-
-    public fun is_trusted_address(
-        self: &InterchainAddressTracker, chain_name: String, address: String
-    ): bool{
-        borrow_trusted_address(self, chain_name) == &address
     }
 }

--- a/move/test/sources/interchain-token-service/interchain_token_channel.move
+++ b/move/test/sources/interchain-token-service/interchain_token_channel.move
@@ -1,21 +1,20 @@
 
 
-
-module interchain_token_service::interchain_token_channel {
+/// Todo: consider nuking?
+module its::interchain_token_channel {
     use sui::object::{Self, UID};
-    use sui::tx_context::{TxContext};
-    
-    struct TokenChannel has store {
-        id: UID,
+    use sui::tx_context::{Self, TxContext};
+
+    /// Identifies a token channel.
+    struct TokenChannel has store, drop {
+        id: address,
     }
 
+    /// Creates a new token channel.
     public fun new(ctx: &mut TxContext): TokenChannel {
-        TokenChannel {
-            id: object::new(ctx),
-        }
+        TokenChannel { id: tx_context::fresh_object_address(ctx) }
     }
 
-    public fun to_address(token_channel: &TokenChannel): address {
-        object::uid_to_address(&token_channel.id)
-    }
+    /// Returns the address of the token channel.
+    public fun to_address(self: &TokenChannel): address { self.id }
 }

--- a/move/test/sources/interchain-token-service/token_id.move
+++ b/move/test/sources/interchain-token-service/token_id.move
@@ -1,6 +1,6 @@
 
 
-module interchain_token_service::token_id {
+module its::token_id {
     use std::ascii;
     use std::vector;
     use std::string::String;
@@ -11,10 +11,10 @@ module interchain_token_service::token_id {
     use sui::address;
     use sui::bcs;
 
-    use interchain_token_service::coin_info::{Self, CoinInfo};
-    use interchain_token_service::coin_management::{Self, CoinManagement};
+    use its::coin_info::{Self, CoinInfo};
+    use its::coin_management::{Self, CoinManagement};
 
-    friend interchain_token_service::service;
+    friend its::service;
 
     // address::to_u256(address::from_bytes(keccak256(&bcs::to_bytes<vector<u8>>(&b"prefix-sui-token-id"))));
     const PREFIX_SUI_TOKEN_ID: u256 = 0x72efd4f4a47bdb9957673d9d0fabc22cad1544bc247ac18367ac54985919bfa3;
@@ -80,7 +80,7 @@ module interchain_token_service::token_id {
     fun test() {
         use std::debug;
         use std::string;
-        use interchain_token_service::coin_info;
+        use its::coin_info;
 
         let prefix = address::to_u256(
             address::from_bytes(

--- a/move/test/sources/interchain-token-service/utils.move
+++ b/move/test/sources/interchain-token-service/utils.move
@@ -1,6 +1,6 @@
 
 
-module interchain_token_service::its_utils {
+module its::utils {
     use std::ascii;
     use std::vector;
 
@@ -77,7 +77,7 @@ module interchain_token_service::its_utils {
     }
 }
 
-module interchain_token_service::thecool1234coin___ {
+module its::thecool1234coin___ {
     use sui::tx_context::{Self, TxContext};
     use sui::coin;
     use std::option;


### PR DESCRIPTION
- removes unnecessary type params
- minor cleanups, ordering
- address is shortened to "its"
- "its::its_utils" -> "its::utils"
- some documentation comments
- simpler TokenChannel (no uid inside)