### PR TITLE
fix(scripts): generalize error handling in `utils.setConfig`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Download and Install Sui Binary
         run: |
-          wget https://github.com/MystenLabs/sui/releases/download/mainnet-v1.19.1/sui-mainnet-v1.19.1-ubuntu-x86_64.tgz
+          wget https://github.com/MystenLabs/sui/releases/download/mainnet-v1.22.0/sui-mainnet-v1.22.0-ubuntu-x86_64.tgz
           tar -xvf sui-mainnet-v1.19.1-ubuntu-x86_64.tgz
           sudo mv ./target/release/sui-test-validator-ubuntu-x86_64 /usr/local/bin/sui-test-validator
           sudo mv ./target/release/sui-ubuntu-x86_64 /usr/local/bin/sui

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Download and Install Sui Binary
         run: |
           wget https://github.com/MystenLabs/sui/releases/download/mainnet-v1.22.0/sui-mainnet-v1.22.0-ubuntu-x86_64.tgz
-          tar -xvf sui-mainnet-v1.19.1-ubuntu-x86_64.tgz
+          tar -xvf sui-mainnet-v1.22.0-ubuntu-x86_64.tgz
           sudo mv ./target/release/sui-test-validator-ubuntu-x86_64 /usr/local/bin/sui-test-validator
           sudo mv ./target/release/sui-ubuntu-x86_64 /usr/local/bin/sui
 
       - name: Cleanup
-        run: rm -rf sui-mainnet-v1.19.1-ubuntu-x86_64.tgz
+        run: rm -rf sui-mainnet-v1.22.0-ubuntu-x86_64.tgz
         
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/move/abi/sources/abi.move
+++ b/move/abi/sources/abi.move
@@ -1,5 +1,4 @@
 module abi::abi {
-    use std::vector;
 
     public struct AbiReader has copy, drop {
         bytes: vector<u8>,

--- a/move/axelar/Move.toml
+++ b/move/axelar/Move.toml
@@ -1,11 +1,11 @@
 [package]
 name = "Axelar"
 version = "0.0.1"
-published-at = "0xf39b12b334eb0711fb6897f758fea3e100533899cfb35cecfc6e1fd690dcd8c7"
+published-at = "0x8a75ac2fd52e8da52da590b2143ae74f945683b2b8d505eb91925598d834afe4"
 edition = "2024.alpha"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
-axelar = "0x0"
+axelar = "0x8a75ac2fd52e8da52da590b2143ae74f945683b2b8d505eb91925598d834afe4"

--- a/move/axelar/Move.toml
+++ b/move/axelar/Move.toml
@@ -1,11 +1,11 @@
 [package]
 name = "Axelar"
 version = "0.0.1"
-published-at = "0x8a75ac2fd52e8da52da590b2143ae74f945683b2b8d505eb91925598d834afe4"
+published-at = "0xf39b12b334eb0711fb6897f758fea3e100533899cfb35cecfc6e1fd690dcd8c7"
 edition = "2024.alpha"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
-axelar = "0x8a75ac2fd52e8da52da590b2143ae74f945683b2b8d505eb91925598d834afe4"
+axelar = "0x0"

--- a/move/its/sources/discovery.move
+++ b/move/its/sources/discovery.move
@@ -183,8 +183,9 @@ module its::discovery {
 
         let type_arg = std::type_name::get<RelayerDiscovery>();
         its.test_add_registered_coin_type(its::token_id::from_address(token_id), type_arg);
-        let call_info = get_call_info(&its, payload);
-        assert!(get_call_info(&its, payload) == get_interchain_transfer_tx(&its, &abi::new_reader(payload)), 1);
+        let mut tx_block = get_call_info(&its, payload);
+        assert!(tx_block == vector[get_interchain_transfer_tx(&its, &abi::new_reader(payload))], 1);
+        let call_info = vector::pop_back(&mut tx_block);
 
         assert!(call_info.function().package_id() == its_package_id(), 2);
         assert!(call_info.function().module_name() == ascii::string(b"service"), 3);
@@ -235,7 +236,7 @@ module its::discovery {
         let payload = writer.into_bytes();
 
         its.test_add_registered_coin_type(its::token_id::from_address(token_id), std::type_name::get<RelayerDiscovery>());
-        assert!(get_call_info(&its, payload) == get_interchain_transfer_tx(&its, &abi::new_reader(payload)), 1);
+        assert!(get_call_info(&its, payload) == vector[get_interchain_transfer_tx(&its, &abi::new_reader(payload))], 1);
         
         sui::test_utils::destroy(its);
         sui::test_utils::destroy(discovery);
@@ -266,9 +267,10 @@ module its::discovery {
 
         let type_arg = std::type_name::get<RelayerDiscovery>();
         its.test_add_unregistered_coin_type(its::token_id::unregistered_token_id(&ascii::string(symbol), (decimals as u8)), type_arg);
-        let call_info = get_call_info(&its, payload);
-        assert!(get_call_info(&its, payload) == get_deploy_interchain_token_tx(&its, &abi::new_reader(payload)), 1);
+        let mut tx_block = get_call_info(&its, payload);
+        assert!(tx_block == vector[get_deploy_interchain_token_tx(&its, &abi::new_reader(payload))], 1);
 
+        let call_info = vector::pop_back(&mut tx_block);
         assert!(call_info.function().package_id() == its_package_id(), 2);
         assert!(call_info.function().module_name() == ascii::string(b"service"), 3);
         assert!(call_info.function().name() == ascii::string(b"receive_deploy_interchain_token"), 4);

--- a/move/its/tests/coin_init_test.move
+++ b/move/its/tests/coin_init_test.move
@@ -1,10 +1,7 @@
 #[test_only]
 module its::thecool1234coin___ {
-    use sui::tx_context::{Self, TxContext};
     use sui::coin;
-    use std::option;
     use sui::url::{Url};
-    use sui::transfer;
 
     public struct THECOOL1234COIN___ has drop{
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -53,7 +53,14 @@ function setConfig(packagePath, envAlias, config) {
         try {
             configs[packagePath] = require(`${__dirname}/../info/${packagePath}.json`);
         } catch(e) {
-            configs[packagePath] = {};
+            switch (e.code) {
+                case 'MODULE_NOT_FOUND':
+                case undefined:
+                    configs[packagePath] = {};
+                    break;
+                default:
+                    throw e;
+            }
         }
     }
     configs[packagePath][envAlias] = config;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -50,12 +50,11 @@ function getConfig(packagePath, envAlias) {
 
 function setConfig(packagePath, envAlias, config) {
     if(!configs[packagePath]) {
-        if (fs.existsSync(`${__dirname}/../info/${packagePath}.json`)) {
-            const content = fs.readFileSync(`${__dirname}/../info/${packagePath}.json`, 'utf8');
-            console.log(`config for ${packagePath} is: "${content}"`);
+        try {
+            configs[packagePath] = require(`${__dirname}/../info/${packagePath}.json`);
+        } catch(e) {
+            configs[packagePath] = {};
         }
-        configs[packagePath] = fs.existsSync(`${__dirname}/../info/${packagePath}.json`) ? require(`${__dirname}/../info/${packagePath}.json`) : {};
-        console.log(configs[packagePath]);
     }
     configs[packagePath][envAlias] = config;
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -52,7 +52,7 @@ function setConfig(packagePath, envAlias, config) {
     if(!configs[packagePath]) {
         if (fs.existsSync(`${__dirname}/../info/${packagePath}.json`)) {
             console.log(`config for ${packagePath} is:`);
-            console.log(fs.readFileSync(`${__dirname}/../info/${packagePath}.json`));
+            console.log(fs.readFileSync(`${__dirname}/../info/${packagePath}.json`, 'utf8'));
         }
         configs[packagePath] = fs.existsSync(`${__dirname}/../info/${packagePath}.json`) ? require(`${__dirname}/../info/${packagePath}.json`) : {};
         console.log(configs[packagePath]);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -50,7 +50,12 @@ function getConfig(packagePath, envAlias) {
 
 function setConfig(packagePath, envAlias, config) {
     if(!configs[packagePath]) {
+        if (fs.existsSync(`${__dirname}/../info/${packagePath}.json`)) {
+            console.log(`config for ${packagePath} is:`);
+            console.log(fs.readFileSync(`${__dirname}/../info/${packagePath}.json`));
+        }
         configs[packagePath] = fs.existsSync(`${__dirname}/../info/${packagePath}.json`) ? require(`${__dirname}/../info/${packagePath}.json`) : {};
+        console.log(configs[packagePath]);
     }
     configs[packagePath][envAlias] = config;
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -51,8 +51,8 @@ function getConfig(packagePath, envAlias) {
 function setConfig(packagePath, envAlias, config) {
     if(!configs[packagePath]) {
         if (fs.existsSync(`${__dirname}/../info/${packagePath}.json`)) {
-            console.log(`config for ${packagePath} is:`);
-            console.log(fs.readFileSync(`${__dirname}/../info/${packagePath}.json`, 'utf8'));
+            const content = fs.readFileSync(`${__dirname}/../info/${packagePath}.json`, 'utf8');
+            console.log(`config for ${packagePath} is: "${content}"`);
         }
         configs[packagePath] = fs.existsSync(`${__dirname}/../info/${packagePath}.json`) ? require(`${__dirname}/../info/${packagePath}.json`) : {};
         console.log(configs[packagePath]);


### PR DESCRIPTION
I have seen `fs.existsSync` returning `true` even if the file doesn't exist, which then results in a json parsing error. So get around this, this PR generalizes error handling via try/catch when parsing package info.