### PR TITLE
test(gas_service): additional coverage

### DIFF
--- a/move/gas_service/sources/gas_service.move
+++ b/move/gas_service/sources/gas_service.move
@@ -279,4 +279,57 @@ module gas_service::gas_service {
         cap.destroy_cap();
         service.destroy();
     }
+
+    #[test]
+    #[expected_failure(abort_code = sui::balance::ENotEnough)]
+    fun test_collect_gas_insufficient_balance() {
+        let ctx = &mut sui::tx_context::dummy();
+        let (mut service, cap) = new(ctx);
+        let value = 10;
+        let c: Coin<SUI> = coin::mint_for_testing(value, ctx);
+
+        service.add_gas(
+            c,
+            std::ascii::string(b"message id"),
+            @0x0,
+            vector[],
+        );
+
+        service.collect_gas(
+            &cap,
+            ctx.sender(),
+            value + 1,
+            ctx,
+        );
+
+        cap.destroy_cap();
+        service.destroy();
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::balance::ENotEnough)]
+    fun test_refund_insufficient_balance() {
+        let ctx = &mut sui::tx_context::dummy();
+        let (mut service, cap) = new(ctx);
+        let value = 10;
+        let c: Coin<SUI> = coin::mint_for_testing(value, ctx);
+
+        service.add_gas(
+            c,
+            std::ascii::string(b"message id"),
+            @0x0,
+            vector[],
+        );
+
+        service.refund(
+            &cap,
+            std::ascii::string(b"message id"),
+            ctx.sender(),
+            value + 1,
+            ctx,
+        );
+
+        cap.destroy_cap();
+        service.destroy();
+    }
 }

--- a/move/gas_service/sources/gas_service.move
+++ b/move/gas_service/sources/gas_service.move
@@ -186,7 +186,9 @@ module gas_service::gas_service {
     fun test_pay_gas() {
         let ctx = &mut sui::tx_context::dummy();
         let (mut service, cap) = new(ctx);
-        let value = 10;
+        // 2 bytes of the digest for a pseudo-random 1..65,536
+        let digest = ctx.digest();
+        let value = (((digest[0] as u16) << 8) | (digest[1] as u16) as u64) + 1;
         let c: Coin<SUI> = coin::mint_for_testing(value, ctx);
 
         service.pay_gas(
@@ -209,7 +211,8 @@ module gas_service::gas_service {
     fun test_add_gas() {
         let ctx = &mut sui::tx_context::dummy();
         let (mut service, cap) = new(ctx);
-        let value = 10;
+        let digest = ctx.digest();
+        let value = (((digest[0] as u16) << 8) | (digest[1] as u16) as u64) + 1; // 1..65,536
         let c: Coin<SUI> = coin::mint_for_testing(value, ctx);
 
         service.add_gas(
@@ -229,7 +232,8 @@ module gas_service::gas_service {
     fun test_collect_gas() {
         let ctx = &mut sui::tx_context::dummy();
         let (mut service, cap) = new(ctx);
-        let value = 10;
+        let digest = ctx.digest();
+        let value = (((digest[0] as u16) << 8) | (digest[1] as u16) as u64) + 1; // 1..65,536
         let c: Coin<SUI> = coin::mint_for_testing(value, ctx);
 
         service.add_gas(
@@ -256,7 +260,8 @@ module gas_service::gas_service {
     fun test_refund() {
         let ctx = &mut sui::tx_context::dummy();
         let (mut service, cap) = new(ctx);
-        let value = 10;
+        let digest = ctx.digest();
+        let value = (((digest[0] as u16) << 8) | (digest[1] as u16) as u64) + 1; // 1..65,536
         let c: Coin<SUI> = coin::mint_for_testing(value, ctx);
 
         service.add_gas(
@@ -285,7 +290,8 @@ module gas_service::gas_service {
     fun test_collect_gas_insufficient_balance() {
         let ctx = &mut sui::tx_context::dummy();
         let (mut service, cap) = new(ctx);
-        let value = 10;
+        let digest = ctx.digest();
+        let value = (((digest[0] as u16) << 8) | (digest[1] as u16) as u64) + 1; // 1..65,536
         let c: Coin<SUI> = coin::mint_for_testing(value, ctx);
 
         service.add_gas(


### PR DESCRIPTION
[AXE-4139]
* [x] `gas_service`: full test coverage

[AXE-4139]: https://axelarnetwork.atlassian.net/browse/AXE-4139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ