### PR TITLE
feat: add copy util to avoid overriding Move.toml for recursive publishes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,4 @@ target/
 *.pdb
 
 # dist and move_compile
-dist
-move_comile
+move_compile

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,11 +77,11 @@ export function updateMoveToml(packageName: string, packageId: string, moveDir: 
 }
 
 export function copyMovePackage(packageName: string, fromDir: null | string, toDir: string) {
-    if(fromDir == null) {
-        fromDir = `${__dirname}/../move`
+    if (fromDir == null) {
+        fromDir = `${__dirname}/../move`;
     }
 
-    fs.cpSync(`${fromDir}/${packageName}`,`${toDir}/${packageName}`, {recursive: true});
+    fs.cpSync(`${fromDir}/${packageName}`, `${toDir}/${packageName}`, { recursive: true });
 }
 
 export function parseEnv(arg: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,6 +76,14 @@ export function updateMoveToml(packageName: string, packageId: string, moveDir: 
     fs.writeFileSync(path, toml);
 }
 
+export function copyMovePackage(packageName: string, fromDir: null | string, toDir: string) {
+    if(fromDir == null) {
+        fromDir = `${__dirname}/../move`
+    }
+
+    fs.cpSync(`${fromDir}/${packageName}`,`${toDir}/${packageName}`, {recursive: true});
+}
+
 export function parseEnv(arg: string) {
     switch (arg?.toLowerCase()) {
         case 'localnet':

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,17 +1,19 @@
 const { keccak256, defaultAbiCoder } = require('ethers/lib/utils');
 const { TxBuilder } = require('../dist/tx-builder');
-const { updateMoveToml } = require('../dist/utils');
+const { updateMoveToml, copyMovePackage } = require('../dist/utils');
 const chai = require('chai');
 const { expect } = chai;
 
 async function publishPackage(client, keypair, packageName) {
+    const compileDir = `${__dirname}/../move_compile`;
+    copyMovePackage(packageName, null, compileDir);
     const builder = new TxBuilder(client);
-    await builder.publishPackageAndTransferCap(packageName, keypair.toSuiAddress());
+    await builder.publishPackageAndTransferCap(packageName, keypair.toSuiAddress(), compileDir);
     const publishTxn = await builder.signAndExecute(keypair);
 
     const packageId = (publishTxn.objectChanges?.find((a) => a.type === 'published') ?? []).packageId;
 
-    updateMoveToml(packageName, packageId);
+    updateMoveToml(packageName, packageId, compileDir);
     return { packageId, publishTxn };
 }
 


### PR DESCRIPTION
[AXE-4427]

[AXE-4427]: https://axelarnetwork.atlassian.net/browse/AXE-4427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ