### PR TITLE
chore: include `move/test` into published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "move",
     "src",
     "tsconfig.json",
-    "!move/**/build",
-    "!move/**/test"
+    "!move/**/build"
   ],
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR added `move/test` into `files` array (by removing the excluding line) because we have a script to deploy it in the contract deployment repo