### PR TITLE
chore: cleanup package.json

### DIFF
--- a/.changeset/itchy-geese-reply.md
+++ b/.changeset/itchy-geese-reply.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-sui': patch
+---
+
+Remove postinstall script and src directory from published content

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,25 @@
 {
   "name": "@axelar-network/axelar-cgp-sui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@axelar-network/axelar-cgp-sui",
-      "version": "0.2.0",
-      "hasInstallScript": true,
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.2",
         "@mysten/sui": "^1.3.0",
-        "@types/tmp": "^0.2.6",
-        "child_process": "^1.0.2",
         "ethers": "^5.0.0",
-        "fs": "^0.0.1-security",
         "secp256k1": "^5.0.0",
         "tmp": "^0.2.1"
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.6",
         "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
+        "@types/node": "^20.14.11",
+        "@types/tmp": "^0.2.6",
         "@typescript-eslint/eslint-plugin": "^7.13.1",
         "@typescript-eslint/parser": "^7.13.1",
         "chai": "^4.3.7",
@@ -2196,9 +2194,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2212,7 +2210,8 @@
     "node_modules/@types/tmp": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA=="
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.16.0",
@@ -2980,11 +2979,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -4406,11 +4400,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/fs-extra": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "files": [
     "dist",
     "move",
-    "src",
     "tsconfig.json",
     "!move/**/build"
   ],
@@ -24,8 +23,7 @@
     "release": "npm run build && changeset publish",
     "cs": "changeset",
     "lint": "eslint --fix './src/*.ts' './test/*.js'",
-    "prettier": "prettier --write './src/*.ts' './test/*.js'",
-    "postinstall": "npm run build-ts"
+    "prettier": "prettier --write './src/*.ts' './test/*.js'"
   },
   "keywords": [
     "axelar",
@@ -39,16 +37,15 @@
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.32.2",
     "@mysten/sui": "^1.3.0",
-    "@types/tmp": "^0.2.6",
-    "child_process": "^1.0.2",
     "ethers": "^5.0.0",
-    "fs": "^0.0.1-security",
     "secp256k1": "^5.0.0",
     "tmp": "^0.2.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.6",
     "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
+    "@types/node": "^20.14.11",
+    "@types/tmp": "^0.2.6",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
     "chai": "^4.3.7",


### PR DESCRIPTION
# Description

After [we've migrated our code](https://github.com/axelarnetwork/axelar-contract-deployments/pull/315) in `axelar-contracts-deployment` repo to use `axelar-cgp-sui@0.3.0`, we can now safely remove the `postinstall` script and the `src` folder from the published content.

This PR also removed `child_process` and `fs` which are included in `node.js` environment, but ts can't detect the type out-of-the-box, so i've also installed `@types/node` type to fix it.