### PR TITLE
chore: fix release workflow

### DIFF
--- a/.changeset/violet-llamas-visit.md
+++ b/.changeset/violet-llamas-visit.md
@@ -1,0 +1,6 @@
+---
+'@axelar-network/axelar-cgp-sui': patch
+---
+
+-   86d7fa3: Include gas payment into test contract's `send_call` function
+-   ab7235b: Remove postinstall script and src directory from published content

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -9,7 +9,7 @@ env:
   SUI_VERSION: mainnet-v1.25.3
 
 jobs:
-  release:
+  release-pr:
     name: Create Release Pull Request
     runs-on: ubuntu-latest
     steps:
@@ -17,16 +17,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for changeset files
-        id: checkfile
+        id: check-changeset-files
         run: |
           if ls .changeset/*.md | grep '\.changeset\/[a-z-]\+\.md$'; then
-            echo "has_file=true" >> "$GITHUB_OUTPUT"
+            echo "has_changeset_files=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_file=false" >> "$GITHUB_OUTPUT"
+            echo "has_changeset_files=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Release Pull Request
-        if: steps.checkfile.outputs.has_file == 'true'
+        if: steps.check-changeset-files.outputs.has_changeset_files == 'true'
         uses: changesets/action@v1
         with:
           title: 'chore: bump version and update changelog'

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -25,11 +25,6 @@ jobs:
             echo "has_file=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Setup Sui CLI and install dependencies
-        uses: ./.github/actions/install
-        with:
-          SUI_VERSION: ${{ env.SUI_VERSION }}
-
       - name: Create Release Pull Request
         if: steps.checkfile.outputs.has_file == 'true'
         uses: changesets/action@v1

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -1,0 +1,40 @@
+name: Create Release Pull Request
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  SUI_VERSION: mainnet-v1.25.3
+
+jobs:
+  release:
+    name: Create Release Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Check for changeset files
+        id: checkfile
+        run: |
+          if ls .changeset/*.md | grep '\.changeset\/[a-z-]\+\.md$'; then
+            echo "has_file=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_file=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Sui CLI and install dependencies
+        uses: ./.github/actions/install
+        with:
+          SUI_VERSION: ${{ env.SUI_VERSION }}
+
+      - name: Create Release Pull Request
+        if: steps.checkfile.outputs.has_file == 'true'
+        uses: changesets/action@v1
+        with:
+          title: 'chore: bump version and update changelog'
+          createGithubReleases: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,9 +1,11 @@
 name: Publish to NPM
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+    types:
+      - closed
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -13,6 +15,9 @@ env:
 jobs:
   publish:
     name: Publish to NPM
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,7 +1,9 @@
-name: Release
+name: Publish to NPM
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -9,20 +11,20 @@ env:
   SUI_VERSION: mainnet-v1.25.3
 
 jobs:
-  release:
-    name: Release
+  publish:
+    name: Publish to NPM
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
       - name: Check for changeset files
-        id: checkfile
+        id: check-changeset-files
         run: |
           if ls .changeset/*.md | grep '\.changeset\/[a-z-]\+\.md$'; then
-            echo "has_file=true" >> "$GITHUB_OUTPUT"
+            echo "has_changeset_files=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_file=false" >> "$GITHUB_OUTPUT"
+            echo "has_changeset_files=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Sui CLI and install dependencies
@@ -30,12 +32,10 @@ jobs:
         with:
           SUI_VERSION: ${{ env.SUI_VERSION }}
 
-      - name: Create Release Pull Request
-        if: steps.checkfile.outputs.has_file == 'true'
+      - name: Publish to NPM
+        if: steps.check-changeset-files.outputs.has_changeset_files == 'false'
         uses: changesets/action@v1
         with:
-          title: 'release: bump version and publish to npm'
-          commit: 'chore: bump version and update changelog'
           publish: npm run release
           createGithubReleases: true
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @axelar-network/axelar-cgp-sui
 
-## 0.3.1
-
-### Patch Changes
-
--   86d7fa3: Include gas payment into test contract's `send_call` function
--   ab7235b: Remove postinstall script and src directory from published content
-
 ## 0.3.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axelar-network/axelar-cgp-sui",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/axelarnetwork/axelar-cgp-sui"


### PR DESCRIPTION
# Description

This PR fixes the release workflow where it doesn't actually publish the package to npm and create GH release when the changeset pr is merged to main branch. 

The reason is that the release workflow is only triggered on workflow dispatch. That means when we merge the changeset PR to main branch, it will never trigger the release workflow to run again.

So, this PR breaks that release workflow into 2 different workflows as follows:
1. `Create Release Pull Request` :  This workflows will create a PR to update changelog. It's triggered **manually** with workflow dispatch.
2. `Publish to NPM`: This workflow will publish the package to NPM and also create a GH release. It's triggered **automatically** when the `Create Release Pull Request` PR is merged to main branch. 