### PR TITLE
chore: fix changeset publish and gh release

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -37,17 +37,13 @@ jobs:
         with:
           SUI_VERSION: ${{ env.SUI_VERSION }}
 
-      - name: Publish to NPM
-        run: |
-          npm publish --no-git-checks --access public
+      - name: Create GitHub Release
+        if: steps.check-changeset-files.outputs.has_changeset_files == 'false'
+        uses: changesets/action@v1
+        with:
+          publish: npm run release
+          createGithubReleases: true
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # TODO: GH release is disabled for now because it's not working
-      # - name: Create GitHub Release
-      #   if: steps.check-changeset-files.outputs.has_changeset_files == 'false'
-      #   uses: changesets/action@v1
-      #   with:
-      #     createGithubReleases: true
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-js": "npx mocha",
     "test": "npm run test-move && npm run test-js",
     "coverage": "./scripts/coverage.sh",
-    "release": "npm run build && npm publish --no-git-checks --access public",
+    "release": "npm run build && changeset publish",
     "cs": "changeset",
     "lint": "eslint --fix './src/*.ts' './test/*.js'",
     "prettier": "prettier --write './src/*.ts' './test/*.js'"


### PR DESCRIPTION
# Description

As I've experimented around the `changeset publish` command on a separate repo. I've found that the reason of [this failed job](https://github.com/axelarnetwork/axelar-cgp-sui/actions/runs/10368105174/job/28700966406) is the missing of `NODE_AUTH_TOKEN` in the `Create GitHub Release` step. So, i've reverted [this changes](https://github.com/axelarnetwork/axelar-cgp-sui/pull/100) and provide `NODE_AUTH_TOKEN` in the `env` vars instead.