### PR TITLE
chore: fix private package when publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "engines": {
     "node": ">=18"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.32.2",
     "@mysten/sui": "^1.3.0",


### PR DESCRIPTION
# Description

In our [recent publish-to-npm job](https://github.com/axelarnetwork/axelar-cgp-sui/actions/runs/10573388992), the package was published as a private package. This PR fixes it by explicitly set  `publishConfig.access` to `public` in `package.json`