### PR TITLE
chore: utillize enum in gateway contract

### DIFF
--- a/move/axelar_gateway/sources/gateway.move
+++ b/move/axelar_gateway/sources/gateway.move
@@ -237,17 +237,6 @@ public fun call_contract(
     })
 }
 
-public fun get_message_status(
-    self: &Gateway,
-    command_id: Bytes32,
-): MessageStatus {
-    if (table::contains(&self.messages, command_id)) {
-        *table::borrow(&self.messages, command_id)
-    } else {
-        MessageStatus::NonExistent
-    }
-}
-
 public fun is_message_approved(
     self: &Gateway,
     source_chain: String,

--- a/move/axelar_gateway/sources/gateway.move
+++ b/move/axelar_gateway/sources/gateway.move
@@ -307,6 +307,7 @@ public fun take_approved_message(
         EMessageNotApproved,
     );
 
+    table::remove(&mut self.messages, command_id);
     table::add(&mut self.messages, command_id, MessageStatus::Executed);
 
     sui::event::emit(MessageExecuted {
@@ -445,8 +446,8 @@ public fun destroy_for_testing(gateway: Gateway) {
 #[test]
 fun test_setup() {
     let ctx = &mut sui::tx_context::dummy();
-    let operator: ERROR = 123456;
-    let domain_separator = bytes32::new(ERROR, 789012);
+    let operator = @123456;
+    let domain_separator = bytes32::new(@789012);
     let minimum_rotation_delay = 765;
     let previous_signers_retention = 650;
     let initial_signers = axelar_gateway::weighted_signers::dummy();
@@ -587,7 +588,7 @@ fun test_approve_message() {
         2,
     );
 
-    let MessageStatus { .. } = gateway.messages.remove(message.command_id());
+    gateway.messages.remove(message.command_id());
 
     gateway.destroy_for_testing();
     channel.destroy();
@@ -698,7 +699,7 @@ fun test_take_approved_message_message_not_approved() {
         .messages
         .add(
             message.command_id(),
-            MessageStatus { status: axelar_gateway::bytes32::new(@0x3) },
+            MessageStatus::Approved(axelar_gateway::bytes32::new(@0x3)),
         );
 
     let approved_message = take_approved_message(
@@ -710,7 +711,7 @@ fun test_take_approved_message_message_not_approved() {
         vector[0, 1, 2],
     );
 
-    let MessageStatus { .. } = gateway.messages.remove(message.command_id());
+    gateway.messages.remove(message.command_id());
 
     approved_message.destroy_for_testing();
     gateway.destroy_for_testing();

--- a/move/axelar_gateway/sources/gateway.move
+++ b/move/axelar_gateway/sources/gateway.move
@@ -68,12 +68,10 @@ public struct Gateway has key {
 }
 
 /// The Status of the message.
-/// Can be either one of three statuses:
-/// - NonExistent
+/// Can be either one of two statuses:
 /// - Approved: Set to the hash of the message
-/// - Execute
+/// - Executed: Message was already executed
 public enum MessageStatus has copy, drop, store {
-    NonExistent,
     Approved(Bytes32),
     Executed,
 }

--- a/move/axelar_gateway/sources/gateway.move
+++ b/move/axelar_gateway/sources/gateway.move
@@ -302,13 +302,18 @@ public fun take_approved_message(
     );
 
     assert!(
-        get_message_status(self, command_id) ==
-        MessageStatus::Approved(message.hash()),
+        is_message_approved(
+            self,
+            source_chain,
+            message_id,
+            source_address,
+            destination_id,
+            bytes32::from_bytes(hash::keccak256(&payload)),
+        ),
         EMessageNotApproved,
     );
 
-    table::remove(&mut self.messages, command_id);
-    table::add(&mut self.messages, command_id, MessageStatus::Executed);
+    *table::borrow_mut(&mut self.messages, command_id) = MessageStatus::Executed;
 
     sui::event::emit(MessageExecuted {
         message,


### PR DESCRIPTION
# Description

[AXE-4734](https://axelarnetwork.atlassian.net/browse/AXE-4734)

This PR uses enum to simplify MessageStatus struct in the gateway contract

[AXE-4734]: https://axelarnetwork.atlassian.net/browse/AXE-4734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ