### PR TITLE
fix: its example for versioned ITS

### DIFF
--- a/move/example/sources/its/its.move
+++ b/move/example/sources/its/its.move
@@ -141,7 +141,7 @@ public fun deploy_remote_interchain_token(
 /// This should trigger an interchain trasnfer.
 public fun send_interchain_transfer_call(
     singleton: &Singleton,
-	its: &mut ITS,
+    its: &mut ITS,
     gateway: &mut Gateway,
     gas_service: &mut GasService,
     token_id: TokenId,
@@ -154,9 +154,7 @@ public fun send_interchain_transfer_call(
     gas_params: vector<u8>,
     clock: &Clock,
 ) {
-    let interchain_transfer_ticket = its::prepare_interchain_transfer<
-        TOKEN,
-    >(
+    let interchain_transfer_ticket = its::prepare_interchain_transfer<TOKEN>(
         token_id,
         coin,
         destination_chain,

--- a/move/example/sources/its/its.move
+++ b/move/example/sources/its/its.move
@@ -141,7 +141,7 @@ public fun deploy_remote_interchain_token(
 /// This should trigger an interchain trasnfer.
 public fun send_interchain_transfer_call(
     singleton: &Singleton,
-    its: &mut ITS,
+	its: &mut ITS,
     gateway: &mut Gateway,
     gas_service: &mut GasService,
     token_id: TokenId,

--- a/test/its.js
+++ b/test/its.js
@@ -28,7 +28,7 @@ const { ITSMessageType } = require('../dist/types');
 const { TxBuilder } = require('../dist/tx-builder');
 const { keccak256, defaultAbiCoder, toUtf8Bytes, hexlify, randomBytes } = require('ethers/lib/utils');
 
-describe.only('ITS', () => {
+describe('ITS', () => {
     // Sui Client
     let client;
     const network = process.env.NETWORK || 'localnet';

--- a/test/its.js
+++ b/test/its.js
@@ -17,6 +17,7 @@ const {
     calculateNextSigners,
     approveMessage,
     getSingletonChannelId,
+    getITSChannelId,
     setupTrustedAddresses,
 } = require('./testutils');
 const { expect } = require('chai');
@@ -127,6 +128,8 @@ describe.only('ITS', () => {
             creatorCap: findObjectId(deployments.axelar_gateway.publishTxn, 'CreatorCap'),
         };
 
+        const itsChannelId = await getITSChannelId(client, objectIds.itsv0);
+
         // Mint some coins for tests
         const tokenTxBuilder = new TxBuilder(client);
 
@@ -140,12 +143,9 @@ describe.only('ITS', () => {
         // Find the object ids from the publish transactions
         objectIds = {
             ...objectIds,
-            itsChannel: await getSingletonChannelId(client, objectIds.its),
-            itsv0Channel: await getSingletonChannelId(client, objectIds.itsv0),
+            itsChannel: itsChannelId,
             token: findObjectId(mintReceipt, 'token::TOKEN'),
         };
-
-        console.log('Itsv0Channel', objectIds.itsv0Channel);
     });
 
     it('should call register_transaction successfully', async () => {
@@ -183,9 +183,7 @@ describe.only('ITS', () => {
         before(async () => {
             await setupGateway();
             await setupGovernance();
-            console.log('Setup trusted addresses');
             await setupTrustedAddresses(client, keypair, gatewayInfo, objectIds, deployments, [trustedSourceAddress], [trustedSourceChain]);
-            console.log('Setup trusted addresses done');
         });
 
         describe('Interchain Token Transfer', () => {

--- a/test/its.js
+++ b/test/its.js
@@ -128,8 +128,6 @@ describe.only('ITS', () => {
             creatorCap: findObjectId(deployments.axelar_gateway.publishTxn, 'CreatorCap'),
         };
 
-        const itsChannelId = await getITSChannelId(client, objectIds.itsv0);
-
         // Mint some coins for tests
         const tokenTxBuilder = new TxBuilder(client);
 
@@ -143,7 +141,7 @@ describe.only('ITS', () => {
         // Find the object ids from the publish transactions
         objectIds = {
             ...objectIds,
-            itsChannel: itsChannelId,
+            itsChannel: await getITSChannelId(client, objectIds.itsv0),
             token: findObjectId(mintReceipt, 'token::TOKEN'),
         };
     });

--- a/test/its.js
+++ b/test/its.js
@@ -27,7 +27,7 @@ const { ITSMessageType } = require('../dist/types');
 const { TxBuilder } = require('../dist/tx-builder');
 const { keccak256, defaultAbiCoder, toUtf8Bytes, hexlify, randomBytes } = require('ethers/lib/utils');
 
-describe('ITS', () => {
+describe.only('ITS', () => {
     // Sui Client
     let client;
     const network = process.env.NETWORK || 'localnet';
@@ -116,7 +116,8 @@ describe('ITS', () => {
             singleton: findObjectId(deployments.example.publishTxn, 'its::Singleton'),
             tokenTreasuryCap: findObjectId(deployments.example.publishTxn, 'TreasuryCap'),
             tokenCoinMetadata: findObjectId(deployments.example.publishTxn, 'CoinMetadata'),
-            its: findObjectId(deployments.its.publishTxn, 'ITS'),
+            its: findObjectId(deployments.its.publishTxn, 'its::ITS'),
+            itsv0: findObjectId(deployments.its.publishTxn, 'its_v0::ITS_V0'),
             relayerDiscovery: findObjectId(
                 deployments.relayer_discovery.publishTxn,
                 `${deployments.relayer_discovery.packageId}::discovery::RelayerDiscovery`,
@@ -140,8 +141,11 @@ describe('ITS', () => {
         objectIds = {
             ...objectIds,
             itsChannel: await getSingletonChannelId(client, objectIds.its),
+            itsv0Channel: await getSingletonChannelId(client, objectIds.itsv0),
             token: findObjectId(mintReceipt, 'token::TOKEN'),
         };
+
+        console.log('Itsv0Channel', objectIds.itsv0Channel);
     });
 
     it('should call register_transaction successfully', async () => {
@@ -179,7 +183,9 @@ describe('ITS', () => {
         before(async () => {
             await setupGateway();
             await setupGovernance();
+            console.log('Setup trusted addresses');
             await setupTrustedAddresses(client, keypair, gatewayInfo, objectIds, deployments, [trustedSourceAddress], [trustedSourceChain]);
+            console.log('Setup trusted addresses done');
         });
 
         describe('Interchain Token Transfer', () => {

--- a/test/its.js
+++ b/test/its.js
@@ -118,7 +118,7 @@ describe('ITS', () => {
             tokenTreasuryCap: findObjectId(deployments.example.publishTxn, 'TreasuryCap'),
             tokenCoinMetadata: findObjectId(deployments.example.publishTxn, 'CoinMetadata'),
             its: findObjectId(deployments.its.publishTxn, 'its::ITS'),
-            itsv0: findObjectId(deployments.its.publishTxn, 'its_v0::ITS_V0'),
+            itsV0: findObjectId(deployments.its.publishTxn, 'its_v0::ITS_v0'),
             relayerDiscovery: findObjectId(
                 deployments.relayer_discovery.publishTxn,
                 `${deployments.relayer_discovery.packageId}::discovery::RelayerDiscovery`,
@@ -141,7 +141,7 @@ describe('ITS', () => {
         // Find the object ids from the publish transactions
         objectIds = {
             ...objectIds,
-            itsChannel: await getITSChannelId(client, objectIds.itsv0),
+            itsChannel: await getITSChannelId(client, objectIds.itsV0),
             token: findObjectId(mintReceipt, 'token::TOKEN'),
         };
     });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -12,7 +12,7 @@ const {
     bcsStructs: {
         gateway: { WeightedSigners, MessageToSign, Proof, Message, Transaction },
         gmp: { Singleton },
-        its: { TrustedAddresses, ITS },
+        its: { TrustedAddresses },
     },
 } = require('../dist/bcs');
 const { newInterchainToken } = require('../dist/utils');

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -359,6 +359,7 @@ const getBcsBytesByObjectId = async (client, objectId) => {
 const getSingletonChannelId = async (client, singletonObjectId) => {
     const bcsBytes = await getBcsBytesByObjectId(client, singletonObjectId);
     const data = Singleton.parse(bcsBytes);
+    console.log('getSingletonChannelId', data);
     return '0x' + data.channel.id;
 };
 
@@ -385,7 +386,11 @@ async function setupTrustedAddresses(client, keypair, gatewayInfo, objectIds, de
         payload_hash: keccak256(payload),
     };
 
+    console.log('destinationId', objectIds.itsChannel);
+
     await approveMessage(client, keypair, gatewayInfo, trustedAddressMessage);
+
+    console.log('Approved trusted address message');
 
     // Set trusted addresses
     const trustedAddressTxBuilder = new TxBuilder(client);
@@ -402,8 +407,10 @@ async function setupTrustedAddresses(client, keypair, gatewayInfo, objectIds, de
         ],
     });
 
+    console.log('Set trusted addresses', [objectIds.gateway, objectIds.governance, approvedMessage]);
+
     await trustedAddressTxBuilder.moveCall({
-        target: `${deployments.its.packageId}::service::set_trusted_addresses`,
+        target: `${deployments.its.packageId}::its::set_trusted_addresses`,
         arguments: [objectIds.its, objectIds.governance, approvedMessage],
     });
 


### PR DESCRIPTION
# Description

This PR fixes test for the new versioned ITS. 

## Changes
- Most changes are due to `service.move` was now merged to `its.move`, so any move calls should be targetted on `its`, instead of `service`. 
- Another change is to update a way to get channelId from the `ITS_V0` object instead of `ITS` object