### PR TITLE
chore: update arg type prefix for clock in its example

### DIFF
--- a/.changeset/moody-buses-happen.md
+++ b/.changeset/moody-buses-happen.md
@@ -1,0 +1,5 @@
+---
+'@axelar-network/axelar-cgp-sui': patch
+---
+
+chore: update argument type for ITS example

--- a/move/example/sources/its/its.move
+++ b/move/example/sources/its/its.move
@@ -63,7 +63,7 @@ public fun register_transaction(
         vector[2u8],
         concat(vector[0u8], object::id_address(singleton).to_bytes()),
         concat(vector[0u8], object::id_address(its).to_bytes()),
-        concat(vector[1u8], object::id_address(clock).to_bytes()),
+        concat(vector[1u8], object::id_bytes(clock)),
     ];
 
     let transaction = transaction::new_transaction(

--- a/move/example/sources/its/its.move
+++ b/move/example/sources/its/its.move
@@ -63,7 +63,7 @@ public fun register_transaction(
         vector[2u8],
         concat(vector[0u8], object::id_address(singleton).to_bytes()),
         concat(vector[0u8], object::id_address(its).to_bytes()),
-        concat(vector[0u8], object::id_address(clock).to_bytes()),
+        concat(vector[1u8], object::id_address(clock).to_bytes()),
     ];
 
     let transaction = transaction::new_transaction(


### PR DESCRIPTION
# Description

Update the argument type in register transaction function for `clockId`, otherwise the client side will left-padding the `clockId` to have 32-bytes length, leading to execution failure.