### PR TITLE
chore: add testnet addresses to deployed sui contracts

### DIFF
--- a/move/axelar_gateway/Move.toml
+++ b/move/axelar_gateway/Move.toml
@@ -2,6 +2,7 @@
 name = "AxelarGateway"
 version = "0.1.0"
 edition = "2024"
+published-at = "0x6ddfcdd14a1019d13485a724db892fa0defe580f19c991eaabd690140abb21e4" #testnet
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet-v1.38.3" }

--- a/move/gas_service/Move.toml
+++ b/move/gas_service/Move.toml
@@ -2,6 +2,8 @@
 name = "GasService"
 version = "0.1.0"
 edition = "2024"
+published-at = "0x3e7044fe789a4f466964e520e4793b467fcdca2d62bef43213d51d0756fc5a75" #testnet
+
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet-v1.38.3" }

--- a/move/operators/Move.toml
+++ b/move/operators/Move.toml
@@ -2,6 +2,8 @@
 name = "Operators"
 version = "0.1.0"
 edition = "2024"
+published-at = "0xbf6b0b743c01709fc636f41d74dd1db15b140bb6bb7ff4897dcf381cbec58db7" #testnet
+
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet-v1.38.3" }

--- a/move/relayer_discovery/Move.toml
+++ b/move/relayer_discovery/Move.toml
@@ -2,6 +2,8 @@
 name = "RelayerDiscovery"
 version = "0.1.0"
 edition = "2024"
+published-at = "0x2f871726329f555bc3fa6eec129f259a8bce3cb3989b39dd75a627a1a0961bc2" #testnet
+
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet-v1.38.3" }

--- a/move/utils/Move.toml
+++ b/move/utils/Move.toml
@@ -2,6 +2,8 @@
 name = "Utils"
 version = "0.1.0"
 edition = "2024"
+published-at = "0x9d817589ae367cc3f3bc9ca40394be79e5853bfca98014f27acfd4da9db78421" #testnet
+
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet-v1.38.3" }

--- a/move/version_control/Move.toml
+++ b/move/version_control/Move.toml
@@ -2,6 +2,7 @@
 name = "VersionControl"
 version = "0.1.0"
 edition = "2024"
+published-at = "0x6e8ebd241a5b89499e0cd104540f8025af111dcd42644bb732dbc170e395ce0c" #testnet
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "mainnet-v1.38.3" }


### PR DESCRIPTION
adding testnet addresses to the config files to be able to use these contracts as dependencies in other repo (for testnet)