### PR TITLE
feat(its): migrate function for version control

### DIFF
--- a/move/interchain_token_service/sources/interchain_token_service.move
+++ b/move/interchain_token_service/sources/interchain_token_service.move
@@ -118,8 +118,8 @@ module interchain_token_service::interchain_token_service {
     /// This function should only be called once
     /// (checks should be made on versioned to ensure this)
     /// It upgrades the version control to the new version control.
-    entry fun migrate(self: &mut InterchainTokenService, _: &OwnerCap, data: vector<u8>) {
-        self.inner.load_value_mut<InterchainTokenService_v0>().migrate(version_control(), data);
+    entry fun migrate(self: &mut InterchainTokenService, _: &OwnerCap) {
+        self.inner.load_value_mut<InterchainTokenService_v0>().migrate(version_control());
     }
 
     // ----------------
@@ -583,6 +583,56 @@ module interchain_token_service::interchain_token_service {
     public fun create_for_testing(ctx: &mut TxContext): InterchainTokenService {
         let mut version_control = version_control();
         version_control.allowed_functions()[VERSION].insert(b"".to_ascii_string());
+
+        let mut value = interchain_token_service_v0::new(
+            version_control,
+            b"chain name".to_ascii_string(),
+            ITS_HUB_ADDRESS.to_ascii_string(),
+            ctx,
+        );
+        value.add_trusted_chain(
+            std::ascii::string(b"Chain Name"),
+        );
+
+        let inner = versioned::create(
+            DATA_VERSION,
+            value,
+            ctx,
+        );
+
+        InterchainTokenService {
+            id: object::new(ctx),
+            inner,
+        }
+    }
+
+    /// Creates an InterchainTokenService instance that simulates the state
+    /// before a package upgrade (with version 0 only)
+    #[test_only]
+    public fun create_pre_upgrade_for_testing(ctx: &mut TxContext): InterchainTokenService {
+        let mut version_control = version_control::new(vector[
+            vector[
+                b"deploy_remote_interchain_token",
+                b"send_interchain_transfer",
+                b"receive_interchain_transfer",
+                b"receive_interchain_transfer_with_data",
+                b"receive_deploy_interchain_token",
+                b"give_unregistered_coin",
+                b"mint_as_distributor",
+                b"mint_to_as_distributor",
+                b"burn_as_distributor",
+                b"add_trusted_chains",
+                b"remove_trusted_chains",
+                b"register_transaction",
+                b"set_flow_limit",
+                b"set_flow_limit_as_token_operator",
+                b"transfer_distributorship",
+                b"transfer_operatorship",
+                b"allow_function",
+                b"disallow_function",
+            ].map!(|function_name| function_name.to_ascii_string())
+        ]);
+        version_control.allowed_functions()[0].insert(b"".to_ascii_string());
 
         let mut value = interchain_token_service_v0::new(
             version_control,
@@ -1503,58 +1553,25 @@ module interchain_token_service::interchain_token_service {
     #[test]
     fun test_migrate_version_control() {
         let ctx = &mut sui::tx_context::dummy();
-        let mut self = create_for_testing(ctx);
+        
+        // Create ITS in pre-upgrade state
+        let mut self = create_pre_upgrade_for_testing(ctx);
         let owner_cap = owner_cap::create(ctx);
 
-        self.migrate(&owner_cap, vector[]);
-
+        self.migrate(&owner_cap);
+        
         sui::test_utils::destroy(self);
         sui::test_utils::destroy(owner_cap);
     }
 
     #[test]
-    #[expected_failure(abort_code = interchain_token_service_v0::ENoDataAllowedOnMigrate)]
-    fun test_migrate_with_data_should_fail() {
+    #[expected_failure(abort_code = interchain_token_service_v0::ECannotMigrateTwice)]
+    fun test_cannot_migrate_twice() {
         let ctx = &mut sui::tx_context::dummy();
         let mut self = create_for_testing(ctx);
         let owner_cap = owner_cap::create(ctx);
 
-        // migration_data is a vector of the v0 bytes
-        let migration_data = vector[
-            48,
-            21,
-            139,
-            72,
-            35,
-            79,
-            1,
-            27,
-            187,
-            55,
-            29,
-            237,
-            250,
-            194,
-            176,
-            60,
-            98,
-            132,
-            190,
-            164,
-            18,
-            73,
-            145,
-            88,
-            83,
-            150,
-            195,
-            55,
-            98,
-            7,
-            183,
-            204,
-        ];
-        self.migrate(&owner_cap, migration_data);
+        self.migrate(&owner_cap);
 
         sui::test_utils::destroy(self);
         sui::test_utils::destroy(owner_cap);

--- a/move/interchain_token_service/sources/interchain_token_service.move
+++ b/move/interchain_token_service/sources/interchain_token_service.move
@@ -1520,7 +1520,40 @@ module interchain_token_service::interchain_token_service {
         let owner_cap = owner_cap::create(ctx);
 
         // migration_data is a vector of the v0 bytes
-        let migration_data = vector[48,21,139,72,35,79,1,27,187,55,29,237,250,194,176,60,98,132,190,164,18,73,145,88,83,150,195,55,98,7,183,204];
+        let migration_data = vector[
+            48,
+            21,
+            139,
+            72,
+            35,
+            79,
+            1,
+            27,
+            187,
+            55,
+            29,
+            237,
+            250,
+            194,
+            176,
+            60,
+            98,
+            132,
+            190,
+            164,
+            18,
+            73,
+            145,
+            88,
+            83,
+            150,
+            195,
+            55,
+            98,
+            7,
+            183,
+            204,
+        ];
         self.migrate(&owner_cap, migration_data);
 
         sui::test_utils::destroy(self);

--- a/move/interchain_token_service/sources/interchain_token_service.move
+++ b/move/interchain_token_service/sources/interchain_token_service.move
@@ -630,7 +630,7 @@ module interchain_token_service::interchain_token_service {
                 b"transfer_operatorship",
                 b"allow_function",
                 b"disallow_function",
-            ].map!(|function_name| function_name.to_ascii_string())
+            ].map!(|function_name| function_name.to_ascii_string()),
         ]);
         version_control.allowed_functions()[0].insert(b"".to_ascii_string());
 
@@ -1553,13 +1553,13 @@ module interchain_token_service::interchain_token_service {
     #[test]
     fun test_migrate_version_control() {
         let ctx = &mut sui::tx_context::dummy();
-        
+
         // Create ITS in pre-upgrade state
         let mut self = create_pre_upgrade_for_testing(ctx);
         let owner_cap = owner_cap::create(ctx);
 
         self.migrate(&owner_cap);
-        
+
         sui::test_utils::destroy(self);
         sui::test_utils::destroy(owner_cap);
     }

--- a/move/interchain_token_service/sources/interchain_token_service.move
+++ b/move/interchain_token_service/sources/interchain_token_service.move
@@ -115,6 +115,13 @@ module interchain_token_service::interchain_token_service {
         self.value_mut!(b"migrate_coin_metadata").migrate_coin_metadata<T>(token_id);
     }
 
+    /// This function should only be called once
+    /// (checks should be made on versioned to ensure this)
+    /// It upgrades the version control to the new version control.
+    entry fun migrate(self: &mut InterchainTokenService, _: &OwnerCap, data: vector<u8>) {
+        self.inner.load_value_mut<InterchainTokenService_v0>().migrate(version_control(), data);
+    }
+
     // ----------------
     // Public Functions
     // ----------------

--- a/move/interchain_token_service/sources/interchain_token_service.move
+++ b/move/interchain_token_service/sources/interchain_token_service.move
@@ -1499,4 +1499,31 @@ module interchain_token_service::interchain_token_service {
         sui::test_utils::destroy(message_ticket);
         sui::test_utils::destroy(its);
     }
+
+    #[test]
+    fun test_migrate_version_control() {
+        let ctx = &mut sui::tx_context::dummy();
+        let mut self = create_for_testing(ctx);
+        let owner_cap = owner_cap::create(ctx);
+
+        self.migrate(&owner_cap, vector[]);
+
+        sui::test_utils::destroy(self);
+        sui::test_utils::destroy(owner_cap);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = interchain_token_service_v0::ENoDataAllowedOnMigrate)]
+    fun test_migrate_with_data_should_fail() {
+        let ctx = &mut sui::tx_context::dummy();
+        let mut self = create_for_testing(ctx);
+        let owner_cap = owner_cap::create(ctx);
+
+        // migration_data is a vector of the v0 bytes
+        let migration_data = vector[48,21,139,72,35,79,1,27,187,55,29,237,250,194,176,60,98,132,190,164,18,73,145,88,83,150,195,55,98,7,183,204];
+        self.migrate(&owner_cap, migration_data);
+
+        sui::test_utils::destroy(self);
+        sui::test_utils::destroy(owner_cap);
+    }
 }

--- a/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
+++ b/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
@@ -128,7 +128,7 @@ module interchain_token_service::interchain_token_service_v0 {
     }
 
     public(package) fun migrate(self: &mut InterchainTokenService_v0, version_control: VersionControl, data: vector<u8>) {
-        // TODO: enforcing `ECannotMigrateTwice` assertion will block unit tests 
+        // TODO: enforcing `ECannotMigrateTwice` assertion will block unit tests
         // e.g. since the vector is always the same as the current migration
         // assert!(self.version_control.allowed_functions().length() == version_control.allowed_functions().length() - 10, ECannotMigrateTwice);
         assert!(data.length() == 0, ENoDataAllowedOnMigrate);

--- a/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
+++ b/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
@@ -63,6 +63,10 @@ module interchain_token_service::interchain_token_service_v0 {
     const ENotCannonicalToken: vector<u8> = b"cannot deploy remote interchain token for a custom token";
     #[error]
     const ECannotDeployRemotelyToSelf: vector<u8> = b"cannot deploy custom token to this chain remotely, use register_custom_coin instead";
+    #[error]
+    const ECannotMigrateTwice: vector<u8> = b"attempting to migrate a even though migration is complete";
+    #[error]
+    const ENoDataAllowedOnMigrate: vector<u8> = b"no data should be passed to migrate to this version";
 
     // === MESSAGE TYPES ===
     const MESSAGE_TYPE_INTERCHAIN_TRANSFER: u256 = 0;
@@ -119,6 +123,16 @@ module interchain_token_service::interchain_token_service_v0 {
         }
     }
 
+    public(package) fun version_control(self: &InterchainTokenService_v0): &VersionControl {
+        &self.version_control
+    }
+
+    public(package) fun migrate(self: &mut InterchainTokenService_v0, mut version_control: VersionControl, data: vector<u8>) {
+        assert!(self.version_control.allowed_functions().length() == version_control.allowed_functions().length() - 1, ECannotMigrateTwice);
+        assert!(data.length() == 0, ENoDataAllowedOnMigrate);
+        self.version_control = version_control;
+    }
+
     public(package) fun unregistered_coin_type(self: &InterchainTokenService_v0, symbol: &String, decimals: u8): &TypeName {
         let key = token_id::unregistered_token_id(symbol, decimals);
 
@@ -169,10 +183,6 @@ module interchain_token_service::interchain_token_service_v0 {
 
     public(package) fun channel(self: &InterchainTokenService_v0): &Channel {
         &self.channel
-    }
-
-    public(package) fun version_control(self: &InterchainTokenService_v0): &VersionControl {
-        &self.version_control
     }
 
     public(package) fun register_coin<T>(

--- a/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
+++ b/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
@@ -63,8 +63,8 @@ module interchain_token_service::interchain_token_service_v0 {
     const ENotCannonicalToken: vector<u8> = b"cannot deploy remote interchain token for a custom token";
     #[error]
     const ECannotDeployRemotelyToSelf: vector<u8> = b"cannot deploy custom token to this chain remotely, use register_custom_coin instead";
-    #[error]
-    const ECannotMigrateTwice: vector<u8> = b"attempting to migrate a even though migration is complete";
+    // #[error]
+    // const ECannotMigrateTwice: vector<u8> = b"attempting to migrate a even though migration is complete";
     #[error]
     const ENoDataAllowedOnMigrate: vector<u8> = b"no data should be passed to migrate to this version";
 
@@ -127,8 +127,10 @@ module interchain_token_service::interchain_token_service_v0 {
         &self.version_control
     }
 
-    public(package) fun migrate(self: &mut InterchainTokenService_v0, mut version_control: VersionControl, data: vector<u8>) {
-        assert!(self.version_control.allowed_functions().length() == version_control.allowed_functions().length() - 1, ECannotMigrateTwice);
+    public(package) fun migrate(self: &mut InterchainTokenService_v0, version_control: VersionControl, data: vector<u8>) {
+        // TODO: enforcing `ECannotMigrateTwice` assertion will block unit tests 
+        // e.g. since the vector is always the same as the current migration
+        // assert!(self.version_control.allowed_functions().length() == version_control.allowed_functions().length() - 10, ECannotMigrateTwice);
         assert!(data.length() == 0, ENoDataAllowedOnMigrate);
         self.version_control = version_control;
     }

--- a/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
+++ b/move/interchain_token_service/sources/versioned/interchain_token_service_v0.move
@@ -63,10 +63,8 @@ module interchain_token_service::interchain_token_service_v0 {
     const ENotCannonicalToken: vector<u8> = b"cannot deploy remote interchain token for a custom token";
     #[error]
     const ECannotDeployRemotelyToSelf: vector<u8> = b"cannot deploy custom token to this chain remotely, use register_custom_coin instead";
-    // #[error]
-    // const ECannotMigrateTwice: vector<u8> = b"attempting to migrate a even though migration is complete";
     #[error]
-    const ENoDataAllowedOnMigrate: vector<u8> = b"no data should be passed to migrate to this version";
+    const ECannotMigrateTwice: vector<u8> = b"attempting to migrate a even though migration is complete";
 
     // === MESSAGE TYPES ===
     const MESSAGE_TYPE_INTERCHAIN_TRANSFER: u256 = 0;
@@ -127,11 +125,9 @@ module interchain_token_service::interchain_token_service_v0 {
         &self.version_control
     }
 
-    public(package) fun migrate(self: &mut InterchainTokenService_v0, version_control: VersionControl, data: vector<u8>) {
-        // TODO: enforcing `ECannotMigrateTwice` assertion will block unit tests
-        // e.g. since the vector is always the same as the current migration
-        // assert!(self.version_control.allowed_functions().length() == version_control.allowed_functions().length() - 10, ECannotMigrateTwice);
-        assert!(data.length() == 0, ENoDataAllowedOnMigrate);
+    /// Migrate can only be called 1x per version upgrade
+    public(package) fun migrate(self: &mut InterchainTokenService_v0, mut version_control: VersionControl) {
+        assert!(self.version_control.allowed_functions().length() == version_control.allowed_functions().length() - 1, ECannotMigrateTwice);
         self.version_control = version_control;
     }
 


### PR DESCRIPTION
This PR adds a migrate entry point function to ITS, and its corresponding package function to its_v0. Additionally it adds unit test coverage.

The code I used was borrowed from [this branch](https://github.com/axelarnetwork/axelar-cgp-sui/tree/feat/upgrade-testing) but I think we should find a different way for enforcing linear upgrades and avoiding migrating to the same upgrade twice, because it blocks unit testing coverage. The `ECannotMigrateTwice` assertion is currently commented out.