### PR TITLE
fix: update move toml and lock files correctly based on version and network

### DIFF
--- a/.changeset/easy-llamas-eat.md
+++ b/.changeset/easy-llamas-eat.md
@@ -1,0 +1,7 @@
+---
+'@axelar-network/axelar-cgp-sui': patch
+---
+
+- deprecated faucet function V0 is updated to V2 (with fallback to V0 for localnet)
+- deprecated type alias TomlPrimitive is updated to TomlValue
+- updateMoveToml now updates move toml and lock files correctly for upgraded contracts

--- a/.changeset/easy-llamas-eat.md
+++ b/.changeset/easy-llamas-eat.md
@@ -2,6 +2,4 @@
 '@axelar-network/axelar-cgp-sui': patch
 ---
 
-- deprecated faucet function V0 is updated to V2 (with fallback to V0 for localnet)
-- deprecated type alias TomlPrimitive is updated to TomlValue
-- updateMoveToml now updates move toml and lock files correctly for upgraded contracts
+updateMoveToml now updates move toml and lock files correctly for upgraded contracts

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -17,6 +17,10 @@ export const fundAccountsFromFaucet = async (addresses: string[]) => {
                 });
             }
 
+            case 'mainnet': {
+                throw new Error(`Faucet request failed, invalid network: ${network}`);
+            }
+
             default: {
                 return requestSuiFromFaucetV2({
                     host: getFaucetHost(network as 'devnet' | 'testnet'),

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -16,6 +16,7 @@ export const fundAccountsFromFaucet = async (addresses: string[]) => {
                     recipient: address,
                 });
             }
+
             default: {
                 return requestSuiFromFaucetV2({
                     host: getFaucetHost(network as 'devnet' | 'testnet'),

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,5 +1,5 @@
 import { getFullnodeUrl, SuiMoveNormalizedType } from '@mysten/sui/client';
-import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
+import { getFaucetHost, requestSuiFromFaucetV0, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { arrayify, keccak256 } from 'ethers/lib/utils';
 import secp256k1 from 'secp256k1';
 import { STD_PACKAGE_ID } from './types';
@@ -8,10 +8,21 @@ export const fundAccountsFromFaucet = async (addresses: string[]) => {
     const promises = addresses.map(async (address) => {
         const network = process.env.NETWORK || 'localnet';
 
-        return requestSuiFromFaucetV2({
-            host: getFaucetHost(network as 'localnet' | 'devnet' | 'testnet'),
-            recipient: address,
-        });
+        switch (network) {
+            case 'localnet': {
+                /// @deprecated: requestSuiFromFaucetV0
+                return requestSuiFromFaucetV0({
+                    host: getFaucetHost('localnet'),
+                    recipient: address,
+                });
+            }
+            default: {
+                return requestSuiFromFaucetV2({
+                    host: getFaucetHost(network as 'devnet' | 'testnet'),
+                    recipient: address,
+                });
+            }
+        }
     });
 
     return Promise.all(promises);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,5 +1,5 @@
 import { getFullnodeUrl, SuiMoveNormalizedType } from '@mysten/sui/client';
-import { getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { arrayify, keccak256 } from 'ethers/lib/utils';
 import secp256k1 from 'secp256k1';
 import { STD_PACKAGE_ID } from './types';
@@ -8,7 +8,7 @@ export const fundAccountsFromFaucet = async (addresses: string[]) => {
     const promises = addresses.map(async (address) => {
         const network = process.env.NETWORK || 'localnet';
 
-        return requestSuiFromFaucetV0({
+        return requestSuiFromFaucetV2({
             host: getFaucetHost(network as 'localnet' | 'devnet' | 'testnet'),
             recipient: address,
         });

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -107,6 +107,14 @@ export function updateMoveToml(
         network = 'testnet';
     }
 
+    if (version) {
+        if (network !== 'devnet' && network !== 'testnet' && network !== 'mainnet') {
+            throw new Error(
+                `Unrecognized chain-id for contract upgrade for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`,
+            );
+        }
+    }
+
     // Path to the Move.toml file for the package
     const movePath = `${moveDir}/${packageName}`;
     const tomlPath = `${movePath}/Move.toml`;
@@ -150,7 +158,11 @@ export function updateMoveToml(
             legacyPackageId = originalPackageId;
         } else if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
             legacyPackageId = (tomlJson as Record<string, Record<string, string>>).package['published-at'];
-            if (!legacyPackageId) throw new Error(`Upgrade parameter missing, no published-at id was found for given path: ${tomlPath}`);
+
+            if (!legacyPackageId) {
+                throw new Error(`Upgrade parameter missing, no published-at id was found for given path: ${tomlPath}`);
+            }
+
             delete (tomlJson as Record<string, Record<string, string>>).package['published-at'];
         }
 
@@ -177,12 +189,6 @@ export function updateMoveToml(
         // [env]
         if (!lockJson.env) {
             lockJson.env = {};
-        }
-
-        if (network !== 'devnet' && network !== 'testnet' && network !== 'mainnet') {
-            throw new Error(
-                `Unrecognized chain-id for contract upgrade for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`,
-            );
         }
 
         // [env.devnet], [env.testnet], [env.mainnet]

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -180,7 +180,9 @@ export function updateMoveToml(
         }
 
         if (network !== 'devnet' && network !== 'testnet' && network !== 'mainnet') {
-            throw new Error(`Unrecognized chain-id for contract upgrade for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`);
+            throw new Error(
+                `Unrecognized chain-id for contract upgrade for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`,
+            );
         }
 
         // [env.testnet] / [env.mainnet]

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -141,7 +141,7 @@ export function updateMoveToml(
         // Update the lock file (lock file must exist)
         if (wasBuilt) {
             // Read the Move.lock file
-            const lockRaw = fs.readFileSync(tomlPath, 'utf8');
+            const lockRaw = fs.readFileSync(lockPath, 'utf8');
             // Parse the Move.lock file as JSON
             lockJson = toml.parse(lockRaw);
 

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -102,6 +102,7 @@ export function updateMoveToml(
     if (!fs.existsSync(tomlPath)) {
         throw new Error(`Move.toml file not found for given path: ${tomlPath}`);
     }
+
     const wasBuilt = fs.existsSync(lockPath);
 
     // Read the Move.toml file
@@ -123,6 +124,7 @@ export function updateMoveToml(
         // Version >= 1
         // Remove the 'published-at' field (if required)
         let legacyPackageId;
+
         if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
             legacyPackageId = (tomlJson as Record<string, Record<string, string>>).package['published-at'];
             if (!legacyPackageId)
@@ -144,10 +146,10 @@ export function updateMoveToml(
 
             // Add the required sections for building versioned dependencies
             // [env]
-            if (!lockJson.hasOwnProperty('env')) lockJson.env = {};
+            if (!lockJson.env) lockJson.env = {};
             // [env.testnet] / [env.mainnet]
             lockJson[`env.${network}`] = {
-                'chain-id': network == 'mainnet' ? chainIds.mainnet : chainIds.testnet,
+                'chain-id': network === 'mainnet' ? chainIds.mainnet : chainIds.testnet,
                 'original-published-id': legacyPackageId,
                 'latest-published-id': packageId,
                 'published-version': String(version + 1),

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -86,7 +86,7 @@ export function updateMoveToml(
     packageId: string,
     moveDir: string = `${__dirname}/../../move`,
     prepToml: undefined | ((tomlJson: Record<string, TomlValue>) => Record<string, TomlValue>) = undefined,
-    // Version should be the 0 indexed variant (as per )
+    // Version should be the 0 indexed variant (as per axelar-contract-deployments chain config)
     version?: undefined | number,
     network?: undefined | string,
 ) {
@@ -158,12 +158,10 @@ export function updateMoveToml(
         } else throw new Error(`Upgrade parameter missing, no lock file was found for given path: ${lockPath}`);
     }
 
-    if (prepToml) {
-        tomlJson = prepToml(tomlJson);
-    }
+    if (prepToml) tomlJson = prepToml(tomlJson);
+    if (lockJson) fs.writeFileSync(lockPath, toml.stringify(lockJson));
 
     fs.writeFileSync(tomlPath, toml.stringify(tomlJson));
-    if (lockJson) fs.writeFileSync(lockPath, toml.stringify(lockJson));
 }
 
 export function copyMovePackage(packageName: string, fromDir: null | string, toDir: string) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -44,7 +44,7 @@ const parseVersion = (version: string) => {
 };
 
 export function getContractBuild(packageName: string, moveDir: string): { modules: string[]; dependencies: string[]; digest: Bytes } {
-    updateMoveToml(packageName, emptyPackageId, moveDir, undefined, undefined, undefined);
+    updateMoveToml(packageName, emptyPackageId, moveDir);
 
     const { tmpdir, rmTmpDir } = prepareMoveBuild(path.dirname(moveDir));
 
@@ -87,8 +87,8 @@ export function updateMoveToml(
     moveDir: string = `${__dirname}/../../move`,
     prepToml: undefined | ((tomlJson: Record<string, TomlValue>) => Record<string, TomlValue>) = undefined,
     // Version should be the 0 indexed variant (as per )
-    version: undefined | number,
-    network: undefined | string,
+    version?: undefined | number,
+    network?: undefined | string,
 ) {
     if (typeof version !== 'number') version = 0;
     if (typeof network !== 'string') network = 'testnet';

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -7,8 +7,8 @@ import { Dependency, DependencyNode, InterchainTokenOptions } from '../common/ty
 
 const emptyPackageId = '0x0';
 const chainIds = {
-    testnet: "4c78adac",
-    mainnet: "35834a8a"
+    testnet: '4c78adac',
+    mainnet: '35834a8a',
 };
 
 /**
@@ -90,13 +90,13 @@ export function updateMoveToml(
     version: undefined | number,
     network: undefined | string,
 ) {
-    if (typeof version !== "number") version = 0;
-    if (typeof network !== "string") network = "testnet";
+    if (typeof version !== 'number') version = 0;
+    if (typeof network !== 'string') network = 'testnet';
 
     // Path to the Move.toml file for the package
     const movePath = `${moveDir}/${packageName}`;
     const tomlPath = `${movePath}/Move.toml`;
-    const lockPath = `${movePath}/Move.lock`
+    const lockPath = `${movePath}/Move.lock`;
 
     // Check if the Move.toml and Move.lock file exists
     if (!fs.existsSync(tomlPath)) {
@@ -119,13 +119,14 @@ export function updateMoveToml(
 
         // Update the package address under the addresses section e.g. gas_service = "0x1"
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
-    // Version >= 1
     } else {
+        // Version >= 1
         // Remove the 'published-at' field (if required)
         let legacyPackageId;
         if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
             legacyPackageId = (tomlJson as Record<string, Record<string, string>>).package['published-at'];
-            if (!legacyPackageId) throw new Error(`Upgrade parameter missing, no original published id was found for given path: ${tomlPath}`);
+            if (!legacyPackageId)
+                throw new Error(`Upgrade parameter missing, no original published id was found for given path: ${tomlPath}`);
             delete (tomlJson as Record<string, Record<string, string>>).package['published-at'];
         }
 
@@ -143,16 +144,15 @@ export function updateMoveToml(
 
             // Add the required sections for building versioned dependencies
             // [env]
-            if (!lockJson.hasOwnProperty("env")) lockJson.env = {};
+            if (!lockJson.hasOwnProperty('env')) lockJson.env = {};
             // [env.testnet] / [env.mainnet]
             lockJson[`env.${network}`] = {
-                "chain-id": (network == "mainnet")? chainIds.mainnet : chainIds.testnet,
-                "original-published-id": legacyPackageId,
-                "latest-published-id": packageId,
-                "published-version": String(version + 1)
+                'chain-id': network == 'mainnet' ? chainIds.mainnet : chainIds.testnet,
+                'original-published-id': legacyPackageId,
+                'latest-published-id': packageId,
+                'published-version': String(version + 1),
             };
-        } else 
-            throw new Error(`Upgrade parameter missing, no lock file was found for given path: ${lockPath}`);
+        } else throw new Error(`Upgrade parameter missing, no lock file was found for given path: ${lockPath}`);
     }
 
     if (prepToml) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -179,6 +179,10 @@ export function updateMoveToml(
             lockJson.env = {};
         }
 
+        if (network !== 'devnet' && network !== 'testnet' && network !== 'mainnet') {
+            throw new Error(`Unrecognized chain-id for contract upgrade for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`);
+        }
+
         // [env.testnet] / [env.mainnet]
         lockJson[`env.${network}`] = {
             'chain-id': chainIds[network as 'devnet' | 'testnet' | 'mainnet'],

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -6,9 +6,9 @@ import toml, { TomlValue } from 'smol-toml';
 import { Dependency, DependencyNode, InterchainTokenOptions } from '../common/types';
 
 type ChainType = {
-    devnet: string,
-    testnet: string,
-    mainnet: string,
+    devnet: string;
+    testnet: string;
+    mainnet: string;
 };
 
 const emptyPackageId = '0x0';
@@ -102,6 +102,7 @@ export function updateMoveToml(
     if (typeof version !== 'number') {
         version = 0;
     }
+
     if (typeof network !== 'string') {
         network = 'testnet';
     }
@@ -115,6 +116,7 @@ export function updateMoveToml(
     if (!fs.existsSync(tomlPath)) {
         throw new Error(`Move.toml file not found for given path: ${tomlPath}`);
     }
+
     const wasBuilt = fs.existsSync(lockPath);
 
     // Read the Move.toml file
@@ -139,9 +141,11 @@ export function updateMoveToml(
         if (!wasBuilt) {
             throw new Error(`Upgrade parameter missing, no lock file was found for given path: ${lockPath}`);
         }
+
         // Version >= 1
         // Remove the 'published-at' field (if required)
         let legacyPackageId;
+
         if (originalPackageId) {
             legacyPackageId = originalPackageId;
         } else if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
@@ -174,6 +178,7 @@ export function updateMoveToml(
         if (!lockJson.env) {
             lockJson.env = {};
         }
+
         // [env.testnet] / [env.mainnet]
         lockJson[`env.${network}`] = {
             'chain-id': chainIds[network as 'devnet' | 'testnet' | 'mainnet'],
@@ -186,6 +191,7 @@ export function updateMoveToml(
     if (prepToml) {
         tomlJson = prepToml(tomlJson);
     }
+
     if (lockJson) {
         fs.writeFileSync(lockPath, toml.stringify(lockJson));
     }

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -127,10 +127,10 @@ export function updateMoveToml(
         // Version >= 1
         // Remove the 'published-at' field (if required)
         let legacyPackageId;
+
         if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
             legacyPackageId = (tomlJson as Record<string, Record<string, string>>).package['published-at'];
-            if (!legacyPackageId) 
-                throw new Error(`Upgrade parameter missing, no published-at id was found for given path: ${tomlPath}`);
+            if (!legacyPackageId) throw new Error(`Upgrade parameter missing, no published-at id was found for given path: ${tomlPath}`);
             delete (tomlJson as Record<string, Record<string, string>>).package['published-at'];
         }
 
@@ -149,8 +149,7 @@ export function updateMoveToml(
             if (!legacyPackageId) {
                 try {
                     legacyPackageId = (lockJson as Record<string, Record<string, string>>)[`env.${network}`]['original-published-id'];
-                } catch(e) {
-                    console.log(e);
+                } catch {
                     throw new Error(`Upgrade parameter missing, no original-published-id was found for given path: ${lockPath}`);
                 }
             }

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -127,7 +127,7 @@ export function updateMoveToml(
         // Version >= 1
         // Remove the 'published-at' field (if required)
         let legacyPackageId;
-        const noPublishedId = `Upgrade parameter missing, no original published id was found for given path: ${tomlPath}`
+        const noPublishedId = `Upgrade parameter missing, no original published id was found for given path: ${tomlPath}`;
         if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
             legacyPackageId = (tomlJson as Record<string, Record<string, string>>).package['published-at'];
             if (!legacyPackageId) throw new Error(noPublishedId);

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -127,13 +127,12 @@ export function updateMoveToml(
         // Version >= 1
         // Remove the 'published-at' field (if required)
         let legacyPackageId;
-
+        const noPublishedId = `Upgrade parameter missing, no original published id was found for given path: ${tomlPath}`
         if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
             legacyPackageId = (tomlJson as Record<string, Record<string, string>>).package['published-at'];
-            if (!legacyPackageId)
-                throw new Error(`Upgrade parameter missing, no original published id was found for given path: ${tomlPath}`);
+            if (!legacyPackageId) throw new Error(noPublishedId);
             delete (tomlJson as Record<string, Record<string, string>>).package['published-at'];
-        }
+        } else throw new Error(noPublishedId);
 
         // Reset the package address in the addresses field to "0x0"
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -110,7 +110,10 @@ export function updateMoveToml(
 
     // Parse the Move.toml file as JSON
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let tomlJson = toml.parse(tomlRaw);
+    let tomlJson: any = toml.parse(tomlRaw);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let lockJson: any;
 
     // Version < 1
     if (!version) {
@@ -136,8 +139,6 @@ export function updateMoveToml(
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
         // Update the lock file (lock file must exist)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let lockJson: any;
         if (wasBuilt) {
             // Read the Move.lock file
             const lockRaw = fs.readFileSync(tomlPath, 'utf8');
@@ -161,7 +162,8 @@ export function updateMoveToml(
         tomlJson = prepToml(tomlJson);
     }
 
-    fs.writeFileSync(movePath, toml.stringify(tomlJson));
+    fs.writeFileSync(tomlPath, toml.stringify(tomlJson));
+    if (lockJson) fs.writeFileSync(lockPath, toml.stringify(lockJson));
 }
 
 export function copyMovePackage(packageName: string, fromDir: null | string, toDir: string) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -185,8 +185,8 @@ export function updateMoveToml(
             );
         }
 
-        // [env.testnet] / [env.mainnet]
-        lockJson[`env.${network}`] = {
+        // [env.devnet], [env.testnet], [env.mainnet]
+        lockJson.env[network] = {
             'chain-id': chainIds[network as 'devnet' | 'testnet' | 'mainnet'],
             'original-published-id': legacyPackageId,
             'latest-published-id': packageId,

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -98,6 +98,7 @@ export function updateMoveToml(
     version?: undefined | number,
     network?: undefined | string,
     originalPackageId?: undefined | string,
+    published?: boolean,
 ) {
     if (typeof version !== 'number') {
         version = 0;
@@ -105,17 +106,11 @@ export function updateMoveToml(
 
     if (typeof network !== 'string') {
         network = 'testnet';
+    } else if (network !== 'devnet' && network !== 'testnet' && network !== 'mainnet') {
+        throw new Error(`Unsupported chain-id for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`);
     }
 
-    if (version) {
-        if (network !== 'devnet' && network !== 'testnet' && network !== 'mainnet') {
-            throw new Error(
-                `Unrecognized chain-id for contract upgrade for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`,
-            );
-        }
-    }
-
-    // Path to the Move.toml file for the package
+    // Path to the Move.toml and Move.lock files for the package
     const movePath = `${moveDir}/${packageName}`;
     const tomlPath = `${movePath}/Move.toml`;
     const lockPath = `${movePath}/Move.lock`;
@@ -124,8 +119,6 @@ export function updateMoveToml(
     if (!fs.existsSync(tomlPath)) {
         throw new Error(`Move.toml file not found for given path: ${tomlPath}`);
     }
-
-    const wasBuilt = fs.existsSync(lockPath);
 
     // Read the Move.toml file
     const tomlRaw = fs.readFileSync(tomlPath, 'utf8');
@@ -137,51 +130,27 @@ export function updateMoveToml(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let lockJson: any;
 
-    // Version < 1 (non-upgrade)
-    if (!version) {
-        // Update the published-at field under the package section e.g. published-at = "0x01"
-        // (only applied to non-upgraded versions)
-        (tomlJson as Record<string, Record<string, string>>).package['published-at'] = packageId;
+    // Retire legacy 'published-at' if required
+    if (tomlJson.package['published-at']) {
+        delete tomlJson.package['published-at'];
+    }
 
-        // Update the package address under the addresses section e.g. gas_service = "0x1"
-        (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
-    } else {
-        if (!wasBuilt) {
-            throw new Error(`Upgrade parameter missing, no lock file was found for given path: ${lockPath}`);
-        }
-
-        // Version >= 1
-        // Remove the 'published-at' field (if required)
-        let legacyPackageId;
-
-        if (originalPackageId) {
-            legacyPackageId = originalPackageId;
-        } else if ((tomlJson as Record<string, Record<string, string>>).package['published-at']) {
-            legacyPackageId = (tomlJson as Record<string, Record<string, string>>).package['published-at'];
-
-            if (!legacyPackageId) {
-                throw new Error(`Upgrade parameter missing, no published-at id was found for given path: ${tomlPath}`);
-            }
-
-            delete (tomlJson as Record<string, Record<string, string>>).package['published-at'];
-        }
-
-        // Reset the package address in the addresses field to "0x0"
+    if (version || published) {
+        // Reset the package address in the addresses field to '0x0'
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
-        // Update the lock file (lock file must exist)
-        // Read the Move.lock file
+        // Read and parse the Move.lock file
         const lockRaw = fs.readFileSync(lockPath, 'utf8');
-        // Parse the Move.lock file as JSON
         lockJson = toml.parse(lockRaw);
 
-        // If syncing an already published upgrade, use 'original-published-id' in place of 'published-at'
-        // for deriving the legacy package id
-        if (!legacyPackageId) {
+        // Determine original-published-id
+        let originalPublishedId = version > 0 ? originalPackageId : packageId;
+
+        if (!originalPublishedId) {
             try {
-                legacyPackageId = (lockJson as Record<string, Record<string, string>>)[`env.${network}`]['original-published-id'];
+                originalPublishedId = lockJson.env[network]['original-published-id'];
             } catch {
-                throw new Error(`Upgrade parameter missing, no original-published-id was found for given path: ${lockPath}`);
+                originalPublishedId = packageId;
             }
         }
 
@@ -194,10 +163,13 @@ export function updateMoveToml(
         // [env.devnet], [env.testnet], [env.mainnet]
         lockJson.env[network] = {
             'chain-id': chainIds[network as 'devnet' | 'testnet' | 'mainnet'],
-            'original-published-id': legacyPackageId,
+            'original-published-id': originalPublishedId,
             'latest-published-id': packageId,
             'published-version': String(version + 1),
         };
+    } else {
+        (tomlJson as Record<string, Record<string, string>>).package['published-at'] = packageId;
+        (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
     }
 
     if (prepToml) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -8,20 +8,26 @@ describe('Utils', () => {
     describe('updateMoveToml', () => {
         const moveTestDir = `${__dirname}/../move-test`;
 
-        it('should insert published-at and address fields correctly', () => {
+        it('should update toml and lock files correctly', () => {
+            const chainId = '4c78adac';
+            const emptyPackageId = '0x0';
+            const testPackageId = '0x0000000000000000000000000000000000000000000000000000000000000001';
             const testPackageName = 'governance';
-            const testPackageId = '0x01';
 
             // Create a new directory for the test package
             copyMovePackage(testPackageName, undefined, moveTestDir);
 
             // Update the Move.toml file for the test package
-            updateMoveToml(testPackageName, testPackageId, moveTestDir);
+            updateMoveToml(testPackageName, testPackageId, moveTestDir, undefined, 0, 'testnet', testPackageId, true);
 
             const moveToml = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.toml`, 'utf8'));
+            const moveLock = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.lock`, 'utf8'));
 
-            expect(moveToml.package['published-at']).to.equal(testPackageId);
-            expect(moveToml.addresses[testPackageName]).to.equal(testPackageId);
+            expect(moveToml.addresses[testPackageName]).to.equal(emptyPackageId);
+            expect(moveLock.env.testnet['chain-id']).to.equal(chainId);
+            expect(moveLock.env.testnet['original-published-id']).to.equal(testPackageId);
+            expect(moveLock.env.testnet['latest-published-id']).to.equal(testPackageId);
+            expect(moveLock.env.testnet['published-version']).to.equal(String(1));
         });
 
         after(async () => {


### PR DESCRIPTION
This PR includes the following changes:

* deprecated faucet function`requestSuiFromFaucetV0` is updated to `requestSuiFromFaucetV2` (with fallback to v0 for `localnet`)
* deprecated type alias `TomlPrimitive` is updated to `TomlValue`
* function `updateMoveToml` now updates move toml and lock files correctly for upgraded contracts, based on three new param inputs: version, sui network and legacy package id