### PR TITLE
chore: refactor move compilation to retire legacy toml format

### DIFF
--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -106,9 +106,7 @@ export function updateMoveToml(
     if (typeof network !== 'string') {
         network = 'testnet';
     } else if (network !== 'devnet' && network !== 'testnet' && network !== 'mainnet') {
-        throw new Error(
-            `Unsupported chain-id for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`,
-        );
+        throw new Error(`Unsupported chain-id for given network ${network}. Must be one of ${JSON.stringify(chainIds)}`);
     }
 
     // Path to the Move.toml and Move.lock files for the package
@@ -120,6 +118,7 @@ export function updateMoveToml(
     if (!fs.existsSync(tomlPath)) {
         throw new Error(`Move.toml file not found for given path: ${tomlPath}`);
     }
+
     const wasBuilt = fs.existsSync(lockPath);
 
     // Read the Move.toml file
@@ -133,23 +132,26 @@ export function updateMoveToml(
     if (tomlJson.package['published-at']) {
         delete tomlJson.package['published-at'];
     }
+
     // Reset the package address in the addresses field to '0x0'
     (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
-    // If this function was called before publishing on-chain, exit gracefully without updating Move.lock 
+    // If this function was called before publishing on-chain, exit gracefully without updating Move.lock
     // as it would add '0x0' to original-published-id and latest-published-id breaking dependency compilation
     // @see: getContractBuild
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let lockJson: any;
+
     if (wasBuilt) {
         // Read and parse the Move.lock file
         const lockRaw = fs.readFileSync(lockPath, 'utf8');
         lockJson = toml.parse(lockRaw);
 
         // Determine original-published-id
-        let originalPublishedId = (version > 0) ? originalPackageId : packageId;
+        let originalPublishedId = version > 0 ? originalPackageId : packageId;
         // Or, derive existing original-published-id from the lock file
         const noLegacyPkgIdMsg = `Upgrade parameter missing, no original-published-id was found for given path: ${lockPath}`;
+
         if (!originalPublishedId && lockJson.env) {
             // Fail if no sub-table exists for current network
             try {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -136,10 +136,10 @@ export function updateMoveToml(
         delete tomlJson.package['published-at'];
     }
 
-    // Reset the package address in the addresses field to '0x0'
-    (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
-
     if (fs.existsSync(lockPath) && packageId.length === defaultPackageIdLength) {
+        // Reset the package address in the addresses field to '0x0'
+        (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
+
         // Read and parse the Move.lock file
         const lockRaw = fs.readFileSync(lockPath, 'utf8');
         lockJson = toml.parse(lockRaw);
@@ -170,6 +170,10 @@ export function updateMoveToml(
             'latest-published-id': packageId,
             'published-version': String(version + 1),
         };
+
+        console.log(lockJson.env.testnet);
+    } else {
+        (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
     }
 
     if (prepToml) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -131,12 +131,12 @@ export function updateMoveToml(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let lockJson: any;
 
-    // Retire legacy 'published-at' if required
-    if (tomlJson.package['published-at']) {
-        delete tomlJson.package['published-at'];
-    }
-
     if (fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
+        // Retire legacy 'published-at' if required
+        if (tomlJson.package['published-at']) {
+            delete tomlJson.package['published-at'];
+        }
+
         // Reset the package address in the addresses field to '0x0'
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
@@ -170,6 +170,7 @@ export function updateMoveToml(
         };
     } else {
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
+        (tomlJson as Record<string, Record<string, string>>).package['published-at'] = packageId;
     }
 
     if (prepToml) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -182,6 +182,8 @@ export function updateMoveToml(
     }
 
     fs.writeFileSync(tomlPath, toml.stringify(tomlJson));
+
+    console.log({ tomlJson, lockJson });
 }
 
 export function copyMovePackage(packageName: string, fromDir: null | string, toDir: string) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -13,7 +13,7 @@ type ChainType = {
 
 const emptyPackageId = '0x0';
 
-const defaultPackageIdLength = 66;
+const suiPackageIdLength = 66;
 
 const chainIds: ChainType = {
     devnet: 'aba3e445',
@@ -136,7 +136,7 @@ export function updateMoveToml(
         delete tomlJson.package['published-at'];
     }
 
-    if (fs.existsSync(lockPath) && packageId.length === defaultPackageIdLength) {
+    if (fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
         // Reset the package address in the addresses field to '0x0'
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
@@ -146,14 +146,11 @@ export function updateMoveToml(
 
         // Determine original-published-id
         let originalPublishedId = version > 0 ? originalPackageId : packageId;
-
-        // Or, derive existing original-published-id from the lock file
-        if (!originalPublishedId && lockJson.env) {
-            // Fail if no sub-table exists for current network
+        if (!originalPublishedId) {
             try {
                 originalPublishedId = lockJson.env[network]['original-published-id'];
             } catch {
-                throw new Error(`Upgrade parameter missing, no original-published-id was found for given path: ${lockPath}`);
+                originalPublishedId = packageId;    
             }
         }
 
@@ -166,7 +163,7 @@ export function updateMoveToml(
         // [env.devnet], [env.testnet], [env.mainnet]
         lockJson.env[network] = {
             'chain-id': chainIds[network as 'devnet' | 'testnet' | 'mainnet'],
-            'original-published-id': originalPublishedId || packageId,
+            'original-published-id': originalPublishedId,
             'latest-published-id': packageId,
             'published-version': String(version + 1),
         };

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -136,7 +136,7 @@ export function updateMoveToml(
         delete tomlJson.package['published-at'];
     }
 
-    if (fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
+    if (version && fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
         // Reset the package address in the addresses field to '0x0'
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
@@ -168,6 +168,8 @@ export function updateMoveToml(
             'latest-published-id': packageId,
             'published-version': String(version + 1),
         };
+
+        console.log(lockJson.env[network]);
     } else {
         (tomlJson as Record<string, Record<string, string>>).package['published-at'] = packageId;
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
@@ -182,8 +184,6 @@ export function updateMoveToml(
     }
 
     fs.writeFileSync(tomlPath, toml.stringify(tomlJson));
-
-    console.log(JSON.stringify({ tomlJson, lockJson }));
 }
 
 export function copyMovePackage(packageName: string, fromDir: null | string, toDir: string) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -170,7 +170,6 @@ export function updateMoveToml(
             'latest-published-id': packageId,
             'published-version': String(version + 1),
         };
-
     } else {
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
     }

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -131,12 +131,12 @@ export function updateMoveToml(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let lockJson: any;
 
-    if (fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
-        // Retire legacy 'published-at' if required
-        if (tomlJson.package['published-at']) {
-            delete tomlJson.package['published-at'];
-        }
+    // Retire legacy 'published-at' if required
+    // if (tomlJson.package['published-at']) {
+    //     delete tomlJson.package['published-at'];
+    // }
 
+    if (fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
         // Reset the package address in the addresses field to '0x0'
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
@@ -169,8 +169,8 @@ export function updateMoveToml(
             'published-version': String(version + 1),
         };
     } else {
-        (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
         (tomlJson as Record<string, Record<string, string>>).package['published-at'] = packageId;
+        (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
     }
 
     if (prepToml) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -146,11 +146,12 @@ export function updateMoveToml(
 
         // Determine original-published-id
         let originalPublishedId = version > 0 ? originalPackageId : packageId;
+
         if (!originalPublishedId) {
             try {
                 originalPublishedId = lockJson.env[network]['original-published-id'];
             } catch {
-                originalPublishedId = packageId;    
+                originalPublishedId = packageId;
             }
         }
 

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -13,8 +13,6 @@ type ChainType = {
 
 const emptyPackageId = '0x0';
 
-const suiPackageIdLength = 66;
-
 const chainIds: ChainType = {
     devnet: 'aba3e445',
     testnet: '4c78adac',
@@ -100,6 +98,7 @@ export function updateMoveToml(
     version?: undefined | number,
     network?: undefined | string,
     originalPackageId?: undefined | string,
+    published?: boolean,
 ) {
     if (typeof version !== 'number') {
         version = 0;
@@ -136,7 +135,7 @@ export function updateMoveToml(
         delete tomlJson.package['published-at'];
     }
 
-    if (version || packageId.length === suiPackageIdLength) {
+    if (version || published) {
         // Reset the package address in the addresses field to '0x0'
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -171,7 +171,6 @@ export function updateMoveToml(
             'published-version': String(version + 1),
         };
 
-        console.log(lockJson.env.testnet);
     } else {
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;
     }

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -168,7 +168,6 @@ export function updateMoveToml(
             'latest-published-id': packageId,
             'published-version': String(version + 1),
         };
-
     } else {
         (tomlJson as Record<string, Record<string, string>>).package['published-at'] = packageId;
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -127,7 +127,7 @@ export function updateMoveToml(
     // Parse the Move.toml file as JSON
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let tomlJson: any = toml.parse(tomlRaw);
-    
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let lockJson: any;
 
@@ -146,6 +146,7 @@ export function updateMoveToml(
 
         // Determine original-published-id
         let originalPublishedId = version > 0 ? originalPackageId : packageId;
+
         // Or, derive existing original-published-id from the lock file
         if (!originalPublishedId && lockJson.env) {
             // Fail if no sub-table exists for current network
@@ -165,7 +166,7 @@ export function updateMoveToml(
         // [env.devnet], [env.testnet], [env.mainnet]
         lockJson.env[network] = {
             'chain-id': chainIds[network as 'devnet' | 'testnet' | 'mainnet'],
-            'original-published-id': originalPublishedId ? originalPublishedId : packageId,
+            'original-published-id': originalPublishedId || packageId,
             'latest-published-id': packageId,
             'published-version': String(version + 1),
         };

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -132,9 +132,9 @@ export function updateMoveToml(
     let lockJson: any;
 
     // Retire legacy 'published-at' if required
-    // if (tomlJson.package['published-at']) {
-    //     delete tomlJson.package['published-at'];
-    // }
+    if (tomlJson.package['published-at']) {
+        delete tomlJson.package['published-at'];
+    }
 
     if (fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
         // Reset the package address in the addresses field to '0x0'
@@ -183,7 +183,7 @@ export function updateMoveToml(
 
     fs.writeFileSync(tomlPath, toml.stringify(tomlJson));
 
-    console.log({ tomlJson, lockJson });
+    console.log(JSON.stringify({ tomlJson, lockJson }));
 }
 
 export function copyMovePackage(packageName: string, fromDir: null | string, toDir: string) {

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -136,7 +136,7 @@ export function updateMoveToml(
         delete tomlJson.package['published-at'];
     }
 
-    if (version && fs.existsSync(lockPath) && packageId.length === suiPackageIdLength) {
+    if (version || packageId.length === suiPackageIdLength) {
         // Reset the package address in the addresses field to '0x0'
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
@@ -169,7 +169,6 @@ export function updateMoveToml(
             'published-version': String(version + 1),
         };
 
-        console.log(lockJson.env[network]);
     } else {
         (tomlJson as Record<string, Record<string, string>>).package['published-at'] = packageId;
         (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = packageId;

--- a/src/node/node-utils.ts
+++ b/src/node/node-utils.ts
@@ -139,7 +139,7 @@ export function updateMoveToml(
     // Reset the package address in the addresses field to '0x0'
     (tomlJson as Record<string, Record<string, string>>).addresses[packageName] = emptyPackageId;
 
-    if (fs.existsSync(lockPath) && packageId.length == defaultPackageIdLength) {
+    if (fs.existsSync(lockPath) && packageId.length === defaultPackageIdLength) {
         // Read and parse the Move.lock file
         const lockRaw = fs.readFileSync(lockPath, 'utf8');
         lockJson = toml.parse(lockRaw);

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const toml = require('smol-toml');
 const fs = require('fs');
 const path = require('path');
-const { updateMoveToml, getLocalDependencies, getContractBuild, copyMovePackage } = require('../dist/cjs');
+const { updateMoveToml, getLocalDependencies, copyMovePackage } = require('../dist/cjs');
 
 describe('Utils', () => {
     describe('updateMoveToml', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const toml = require('smol-toml');
 const fs = require('fs');
 const path = require('path');
-const { updateMoveToml, getLocalDependencies, copyMovePackage, getContractBuild } = require('../dist/cjs');
+const { updateMoveToml, getLocalDependencies, copyMovePackage } = require('../dist/cjs');
 
 describe('Utils', () => {
     describe('updateMoveToml', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,12 +5,11 @@ const path = require('path');
 const { updateMoveToml, getLocalDependencies, copyMovePackage } = require('../dist/cjs');
 
 describe('Utils', () => {
+    // TODO: make contract building work for tests to test lock files
     describe('updateMoveToml', () => {
         const moveTestDir = `${__dirname}/../move-test`;
 
-        it('should update toml and lock files correctly', () => {
-            // const chainId = '4c78adac';
-            const emptyPackageId = '0x0';
+        it('should update addresses in Move.toml correctly', () => {
             const testPackageId = '0x01';
             const testPackageName = 'governance';
 
@@ -21,13 +20,10 @@ describe('Utils', () => {
             updateMoveToml(testPackageName, testPackageId, moveTestDir);
 
             const moveToml = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.toml`, 'utf8'));
-            // const moveLock = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.lock`, 'utf8'));
 
-            expect(moveToml.addresses[testPackageName]).to.equal(emptyPackageId);
-            // expect(moveLock.env.testnet['chain-id']).to.equal(chainId);
-            // expect(moveLock.env.testnet['original-published-id']).to.equal(testPackageId);
-            // expect(moveLock.env.testnet['latest-published-id']).to.equal(testPackageId);
-            // expect(moveLock.env.testnet['published-version']).to.equal(String(1));
+            // Unpublished builds use package id (this avoids dependency collisions)
+            // published builds reset addresses to '0x0'
+            expect(moveToml.addresses[testPackageName]).to.equal(testPackageId);
         });
 
         after(async () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,15 +11,12 @@ describe('Utils', () => {
         it('should update toml and lock files correctly', () => {
             // const chainId = '4c78adac';
             const emptyPackageId = '0x0';
-            const testPackageId = '0x0000000000000000000000000000000000000000000000000000000000000001';
+            const testPackageId = '0x01';
             const testPackageName = 'governance';
 
             // Create a new directory for the test package
             copyMovePackage(testPackageName, undefined, moveTestDir);
-
-            // Build package
-            // getContractBuild(testPackageName, moveTestDir);
-
+            
             // Update the Move.toml file for the test package
             updateMoveToml(testPackageName, testPackageId, moveTestDir);
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -18,7 +18,7 @@ describe('Utils', () => {
             copyMovePackage(testPackageName, undefined, moveTestDir);
 
             // Update the Move.toml file for the test package
-            updateMoveToml(testPackageName, testPackageId, moveTestDir);
+            updateMoveToml(testPackageName, testPackageId, moveTestDir, undefined, 0, 'testnet', testPackageId, true);
 
             const moveToml = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.toml`, 'utf8'));
             const moveLock = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.lock`, 'utf8'));

--- a/test/utils.js
+++ b/test/utils.js
@@ -16,7 +16,7 @@ describe('Utils', () => {
 
             // Create a new directory for the test package
             copyMovePackage(testPackageName, undefined, moveTestDir);
-            
+
             // Update the Move.toml file for the test package
             updateMoveToml(testPackageName, testPackageId, moveTestDir);
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,26 +2,35 @@ const { expect } = require('chai');
 const toml = require('smol-toml');
 const fs = require('fs');
 const path = require('path');
-const { updateMoveToml, getLocalDependencies, copyMovePackage } = require('../dist/cjs');
+const { updateMoveToml, getLocalDependencies, getContractBuild, copyMovePackage } = require('../dist/cjs');
 
 describe('Utils', () => {
     describe('updateMoveToml', () => {
         const moveTestDir = `${__dirname}/../move-test`;
 
-        it('should insert published-at and address fields correctly', () => {
+        it('should update toml and lock files correctly', () => {
+            // const chainId = '4c78adac';
+            const emptyPackageId = '0x0';
+            const testPackageId = '0x0000000000000000000000000000000000000000000000000000000000000001';
             const testPackageName = 'governance';
-            const testPackageId = '0x01';
 
             // Create a new directory for the test package
             copyMovePackage(testPackageName, undefined, moveTestDir);
+
+            // Build package
+            // getContractBuild(testPackageName, moveTestDir);
 
             // Update the Move.toml file for the test package
             updateMoveToml(testPackageName, testPackageId, moveTestDir);
 
             const moveToml = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.toml`, 'utf8'));
+            // const moveLock = toml.parse(fs.readFileSync(`${moveTestDir}/${testPackageName}/Move.lock`, 'utf8'));
 
-            expect(moveToml.package['published-at']).to.equal(testPackageId);
-            expect(moveToml.addresses[testPackageName]).to.equal(testPackageId);
+            expect(moveToml.addresses[testPackageName]).to.equal(emptyPackageId);
+            // expect(moveLock.env.testnet['chain-id']).to.equal(chainId);
+            // expect(moveLock.env.testnet['original-published-id']).to.equal(testPackageId);
+            // expect(moveLock.env.testnet['latest-published-id']).to.equal(testPackageId);
+            // expect(moveLock.env.testnet['published-version']).to.equal(String(1));
         });
 
         after(async () => {


### PR DESCRIPTION
This PR refactors Move compilation to retire the legacy toml format that uses the `[addresses]` table and `published-at` field to determine on-chain dependencies. 

The PR has been on-chain and confirmed to be working as expected. More specifically, the following requirements have been tested:

- Deploying new contracts works
- Upgrading contracts works
- `sync` command is no longer required post-upgrade (toml / lock are updated automatically)
- `sync` command can be used to update all contracts with legacy toml / lock format to the new format
- `updateMoveToml` remains backwards compatible, making it safe to merge the [implementation PR](https://github.com/axelarnetwork/axelar-contract-deployments/pull/1038) before publishing 1.2.0 to npm (as long as no one runs the `sync` command which will fail)
- Compiling without publishing succeeds (no unpublished addresses are added to the Lock file)