### PR TITLE
ci: use GitHub App token in release workflows

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -70,6 +70,13 @@ jobs:
           echo "new_package_version=${NEW_PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "old_package_version=${OLD_PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       # Keep the version of the PRs up-to-date
       - name: Create Release Pull Request
         id: release-pr
@@ -80,4 +87,4 @@ jobs:
           title: 'chore(release): bump version from `${{ steps.extract-package-versions.outputs.old_package_version }}` to `${{ steps.extract-package-versions.outputs.new_package_version }}`'
           commit: 'chore(release): bump version from `${{ steps.extract-package-versions.outputs.old_package_version }}` to `${{ steps.extract-package-versions.outputs.new_package_version }}`'
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,13 @@ jobs:
           install-sui: 'true'
           install-nodejs: 'true'
 
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       # Publishes a release in case the release isn't published
       - name: Publish release
         uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1.4.7
@@ -39,6 +46,6 @@ jobs:
           publish: npm run release
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Replace PAT_TOKEN with a short-lived token generated via the actions/create-github-app-token action. Same pattern as https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/372.

Part of CPI-302